### PR TITLE
Add core RBAC models, migrations, and tests

### DIFF
--- a/apps/api/app/db/__init__.py
+++ b/apps/api/app/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities and models for AgentFlow."""
+
+from .base import Base
+
+__all__ = ["Base"]

--- a/apps/api/app/db/base.py
+++ b/apps/api/app/db/base.py
@@ -1,0 +1,9 @@
+"""SQLAlchemy base declaration."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Base class for all ORM models."""
+
+    pass

--- a/apps/api/app/db/models.py
+++ b/apps/api/app/db/models.py
@@ -1,0 +1,90 @@
+"""Database models for core RBAC entities."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import List
+
+from sqlalchemy import DateTime, ForeignKey, String, Uuid
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class Organization(Base):
+    __tablename__ = "organizations"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    agents: Mapped[List["Agent"]] = relationship(
+        back_populates="organization", cascade="all, delete-orphan"
+    )
+    memberships: Mapped[List["Membership"]] = relationship(
+        back_populates="organization", cascade="all, delete-orphan"
+    )
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(200), unique=True, nullable=False)
+    hashed_password: Mapped[str] = mapped_column(String(200), nullable=False)
+    memberships: Mapped[List["Membership"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    api_keys: Mapped[List["APIKey"]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+
+
+class Agent(Base):
+    __tablename__ = "agents"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(200), nullable=False)
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE")
+    )
+    organization: Mapped[Organization] = relationship(back_populates="agents")
+
+
+class Role(Base):
+    __tablename__ = "roles"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    name: Mapped[str] = mapped_column(String(50), unique=True, nullable=False)
+    memberships: Mapped[List["Membership"]] = relationship(
+        back_populates="role", cascade="all, delete-orphan"
+    )
+
+
+class Membership(Base):
+    __tablename__ = "memberships"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE")
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("organizations.id", ondelete="CASCADE")
+    )
+    role_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("roles.id", ondelete="CASCADE")
+    )
+    user: Mapped[User] = relationship(back_populates="memberships")
+    organization: Mapped[Organization] = relationship(back_populates="memberships")
+    role: Mapped[Role] = relationship(back_populates="memberships")
+
+
+class APIKey(Base):
+    __tablename__ = "api_keys"
+
+    id: Mapped[uuid.UUID] = mapped_column(Uuid, primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"))
+    hashed_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    user: Mapped[User] = relationship(back_populates="api_keys")

--- a/apps/api/app/db/seeds.py
+++ b/apps/api/app/db/seeds.py
@@ -1,0 +1,47 @@
+"""Seed database with initial roles and sample user/org."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+from pydantic import BaseModel, EmailStr, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..exceptions import SeedError
+from ..utils.crypto import encrypt
+from .models import APIKey, Membership, Organization, Role, User
+
+
+class SeedData(BaseModel):
+    org_name: str = Field(default="Example Org", max_length=200)
+    user_email: EmailStr = "user@example.com"
+    user_password: str = Field(default="change-me", min_length=8)
+
+
+async def seed_initial_data(session: AsyncSession) -> None:
+    """Create default roles and a sample organization with user."""
+    data = SeedData()
+    try:
+        existing = {r.name for r in (await session.scalars(select(Role))).all()}
+        for name in ("admin", "member", "viewer"):
+            if name not in existing:
+                session.add(Role(name=name))
+        await session.flush()
+
+        org = Organization(name=data.org_name)
+        hashed = hashlib.sha256(data.user_password.encode()).hexdigest()
+        user = User(email=data.user_email, hashed_password=hashed)
+        session.add_all([org, user])
+        await session.flush()
+
+        admin = await session.scalar(select(Role).where(Role.name == "admin"))
+        session.add(Membership(user_id=user.id, organization_id=org.id, role_id=admin.id))
+
+        raw_key = os.getenv("SEED_API_KEY") or secrets.token_hex(16)
+        session.add(APIKey(user_id=user.id, hashed_key=encrypt(raw_key)))
+        await session.commit()
+    except Exception as exc:  # pragma: no cover - unexpected
+        await session.rollback()
+        raise SeedError("Failed to seed initial data") from exc

--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -1,0 +1,24 @@
+"""Database session utilities."""
+
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from ..config import get_settings
+from ..exceptions import AgentFlowError
+
+_engine = create_async_engine(get_settings().database_url, future=True)
+_Session = async_sessionmaker(_engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Provide a database session and ensure proper cleanup."""
+    try:
+        async with _Session() as session:
+            yield session
+    except Exception as exc:  # pragma: no cover - infrastructure failure
+        raise AgentFlowError("Database session error") from exc

--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -19,3 +19,11 @@ class HealthCheckError(AgentFlowError):
     def __init__(self, service: str, message: str):
         super().__init__(message)
         self.service = service
+
+
+class RBACError(AgentFlowError):
+    """Raised when permission checks fail or cannot be completed."""
+
+
+class SeedError(AgentFlowError):
+    """Raised when database seeding operations fail."""

--- a/apps/api/app/utils/rbac.py
+++ b/apps/api/app/utils/rbac.py
@@ -1,0 +1,43 @@
+"""Role-based access control utilities."""
+
+from __future__ import annotations
+
+import uuid
+from typing import Dict, Set
+
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..db.models import Membership, Role
+from ..exceptions import RBACError
+
+PERMISSIONS: Dict[str, Dict[str, Set[str]]] = {
+    "admin": {"*": {"*"}},
+    "member": {"agents": {"read", "write"}},
+    "viewer": {"agents": {"read"}},
+}
+
+
+class PermissionRequest(BaseModel):
+    user_id: uuid.UUID
+    org_id: uuid.UUID
+    resource: str = Field(max_length=50)
+    action: str = Field(max_length=50)
+
+
+async def check_permission(session: AsyncSession, req: PermissionRequest) -> bool:
+    """Return True if the user's role allows the action on the resource."""
+    try:
+        stmt = select(Role.name).join(Membership).where(
+            Membership.user_id == req.user_id,
+            Membership.organization_id == req.org_id,
+        )
+        role = await session.scalar(stmt)
+        if not role:
+            return False
+        perms = PERMISSIONS.get(role, {})
+        actions = perms.get(req.resource, perms.get("*", set()))
+        return req.action in actions or "*" in actions
+    except Exception as exc:  # pragma: no cover - unexpected
+        raise RBACError("Permission check failed") from exc

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,43 @@
+"""Alembic environment for AgentFlow."""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from apps.api.app.db.base import Base
+
+config = context.config
+if config.config_file_name:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in offline mode."""
+    url = os.getenv("DATABASE_URL")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in online mode."""
+    url = os.getenv("DATABASE_URL")
+    connectable = engine_from_config(
+        {"sqlalchemy.url": url}, prefix="", poolclass=pool.NullPool
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/versions/0002_core_tables.py
+++ b/migrations/versions/0002_core_tables.py
@@ -1,0 +1,50 @@
+"""create core tables"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_core_tables"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table("organizations",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(200), nullable=False, unique=True))
+    op.create_table("users",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("email", sa.String(200), nullable=False, unique=True),
+        sa.Column("hashed_password", sa.String(200), nullable=False))
+    op.create_table("roles",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(50), nullable=False, unique=True))
+    op.create_table("agents",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(200), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+    )
+    op.create_table("memberships",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("organization_id", sa.Uuid(), sa.ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("role_id", sa.Uuid(), sa.ForeignKey("roles.id", ondelete="CASCADE"), nullable=False),
+    )
+    op.create_table("api_keys",
+        sa.Column("id", sa.Uuid(), primary_key=True, nullable=False),
+        sa.Column("user_id", sa.Uuid(), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("hashed_key", sa.String(255), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("api_keys")
+    op.drop_table("memberships")
+    op.drop_table("agents")
+    op.drop_table("roles")
+    op.drop_table("users")
+    op.drop_table("organizations")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
   "qdrant-client>=1.9.0",
   "redis>=5.0.7",
   "SQLAlchemy>=2.0",
+  "alembic>=1.13",
   "psycopg[binary]>=3.2",
   "httpx>=0.27",
     "r2r>=0.1.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest_asyncio
+import pathlib
+import sys
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from apps.api.app.db.base import Base
+from apps.api.app.exceptions import AgentFlowError
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    """Provide a transactional in-memory database session for tests."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        Session = async_sessionmaker(engine, expire_on_commit=False)
+        async with Session() as session:
+            yield session
+    except Exception as exc:  # pragma: no cover - test setup failure
+        raise AgentFlowError("Test DB setup failed") from exc
+    finally:
+        await engine.dispose()

--- a/tests/db/test_models.py
+++ b/tests/db/test_models.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy import select
+
+from apps.api.app.db.models import (
+    APIKey,
+    Agent,
+    Membership,
+    Organization,
+    Role,
+    User,
+)
+
+
+@pytest.mark.asyncio
+async def test_model_relationships(session) -> None:
+    org = Organization(name="Org")
+    user = User(email="u@example.com", hashed_password="pwd")
+    role = Role(name="admin")
+    session.add_all([org, user, role])
+    await session.flush()
+    session.add(Membership(user_id=user.id, organization_id=org.id, role_id=role.id))
+    session.add(Agent(name="Bot", organization_id=org.id))
+    session.add(APIKey(user_id=user.id, hashed_key="hk"))
+    await session.commit()
+    mem = await session.scalar(select(Membership).where(Membership.user_id == user.id))
+    assert mem.role_id == role.id
+    agent = await session.scalar(select(Agent).where(Agent.organization_id == org.id))
+    assert agent.name == "Bot"

--- a/tests/db/test_seeds.py
+++ b/tests/db/test_seeds.py
@@ -1,0 +1,17 @@
+import pytest
+from sqlalchemy import select
+
+from apps.api.app.db.models import Organization, Role, User
+from apps.api.app.db.seeds import seed_initial_data
+
+
+@pytest.mark.asyncio
+async def test_seed_initial_data(session, monkeypatch) -> None:
+    monkeypatch.setenv("SEED_API_KEY", "testkey")
+    await seed_initial_data(session)
+    roles = await session.scalars(select(Role))
+    assert {r.name for r in roles} == {"admin", "member", "viewer"}
+    org = await session.scalar(select(Organization))
+    user = await session.scalar(select(User))
+    assert org.name == "Example Org"
+    assert user.email == "user@example.com"

--- a/tests/utils/test_rbac.py
+++ b/tests/utils/test_rbac.py
@@ -1,0 +1,25 @@
+import pytest
+
+from apps.api.app.db.models import Membership, Organization, Role, User
+from apps.api.app.utils.rbac import PermissionRequest, check_permission
+
+
+@pytest.mark.asyncio
+async def test_check_permission(session) -> None:
+    org = Organization(name="Org")
+    user = User(email="u@example.com", hashed_password="pwd")
+    role = Role(name="viewer")
+    session.add_all([org, user, role])
+    await session.flush()
+    session.add(Membership(user_id=user.id, organization_id=org.id, role_id=role.id))
+    await session.commit()
+    allowed = await check_permission(
+        session,
+        PermissionRequest(user_id=user.id, org_id=org.id, resource="agents", action="read"),
+    )
+    denied = await check_permission(
+        session,
+        PermissionRequest(user_id=user.id, org_id=org.id, resource="agents", action="write"),
+    )
+    assert allowed is True
+    assert denied is False


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for organizations, users, agents, roles, memberships, and API keys
- add Alembic migration and environment setup
- implement RBAC permission check utility and seed data
- introduce unit tests and test fixtures

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a559af03148322886ae9683a0e67c4