### PR TITLE
Add JWT authentication with audit logging

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     r2r_base_url: str = "http://localhost:7272"
     r2r_api_key: str | None = None
     log_level: str = "INFO"
+    password_min_length: int = 8
+    access_token_ttl_minutes: int = 15
+    refresh_token_ttl_minutes: int = 60 * 24
 
 
 @lru_cache()

--- a/apps/api/app/dependencies.py
+++ b/apps/api/app/dependencies.py
@@ -1,28 +1,31 @@
 from typing import List
 from fastapi import Depends, HTTPException, status
-from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel
 
+from .exceptions import TokenError
+from .services import auth as auth_service
+
 security = HTTPBearer()
+
 
 class User(BaseModel):
     sub: str
     roles: List[str] = []
 
-async def get_current_user(credentials: HTTPAuthorizationCredentials = Depends(security)) -> User:
-    token = credentials.credentials
-    if not token or token == "invalid":
+
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(security),
+) -> User:
+    try:
+        sub = await auth_service.decode_token(credentials.credentials)
+    except TokenError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid authentication credentials",
+            detail=str(exc),
             headers={"WWW-Authenticate": "Bearer"},
         )
-    try:
-        user_id, roles_str = token.split(":", 1)
-        roles = [r for r in roles_str.split(",") if r]
-    except ValueError:
-        user_id, roles = token, []
-    return User(sub=user_id, roles=roles)
+    return User(sub=sub, roles=[])
 
 def require_roles(required: List[str]):
     async def role_checker(user: User = Depends(get_current_user)) -> User:

--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -27,3 +27,15 @@ class RBACError(AgentFlowError):
 
 class SeedError(AgentFlowError):
     """Raised when database seeding operations fail."""
+
+
+class AuthenticationError(AgentFlowError):
+    """Raised when authentication fails."""
+
+
+class InvalidCredentialsError(AuthenticationError):
+    """Raised when user credentials are invalid."""
+
+
+class TokenError(AuthenticationError):
+    """Raised when token generation or validation fails."""

--- a/apps/api/app/middleware.py
+++ b/apps/api/app/middleware.py
@@ -1,17 +1,36 @@
 """FastAPI middleware for audit logging."""
+from __future__ import annotations
+
+import json
 import time
+
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
 
+
 class AuditMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        body = await request.body()
+        request._body = body
         start = time.time()
         response = await call_next(request)
         duration = (time.time() - start) * 1000
+        event = "auth" if request.url.path.startswith("/auth") else "request"
+        email = None
+        if event == "auth":
+            try:
+                email = json.loads(body.decode()).get("email")
+            except Exception:  # pragma: no cover - best effort
+                email = None
         logger.info(
-            "audit", method=request.method, path=request.url.path,
-            status=response.status_code, duration_ms=round(duration, 2)
+            "audit",
+            event=event,
+            method=request.method,
+            path=request.url.path,
+            status=response.status_code,
+            email=email,
+            duration_ms=round(duration, 2),
         )
         return response

--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -1,0 +1,21 @@
+"""Pydantic models for authentication."""
+from pydantic import BaseModel, EmailStr
+
+
+class UserCreate(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class LoginRequest(UserCreate):
+    pass
+
+
+class RefreshRequest(BaseModel):
+    refresh_token: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"

--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -1,9 +1,39 @@
-from fastapi import APIRouter
+"""Authentication router."""
+from fastapi import APIRouter, HTTPException
+
+from ..exceptions import InvalidCredentialsError, TokenError
+from ..models.auth import LoginRequest, RefreshRequest, TokenResponse, UserCreate
+from ..services import auth as auth_service
 
 router = APIRouter()
 
-@router.post("/login")
-async def login(email: str, password: str) -> dict:
-    # In lieu of real authentication, echo back a token with "user" role.
-    token = f"{email}:user"
-    return {"access_token": token, "token_type": "bearer"}
+
+@router.post("/register", status_code=201)
+async def register(user: UserCreate) -> dict:
+    try:
+        await auth_service.register_user(user.email, user.password)
+    except InvalidCredentialsError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"status": "ok"}
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(credentials: LoginRequest) -> TokenResponse:
+    try:
+        await auth_service.authenticate_user(credentials.email, credentials.password)
+        access = await auth_service.create_access_token(credentials.email)
+        refresh = await auth_service.create_refresh_token(credentials.email)
+        return TokenResponse(access_token=access, refresh_token=refresh)
+    except InvalidCredentialsError as exc:
+        raise HTTPException(status_code=401, detail=str(exc))
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(token: RefreshRequest) -> TokenResponse:
+    try:
+        subject = await auth_service.decode_token(token.refresh_token)
+        access = await auth_service.create_access_token(subject)
+        refresh_token = await auth_service.create_refresh_token(subject)
+        return TokenResponse(access_token=access, refresh_token=refresh_token)
+    except TokenError as exc:
+        raise HTTPException(status_code=401, detail=str(exc))

--- a/apps/api/app/services/auth.py
+++ b/apps/api/app/services/auth.py
@@ -1,0 +1,58 @@
+"""Authentication service utilities."""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta
+from typing import Dict
+
+import jwt
+
+from .. import config
+from ..exceptions import InvalidCredentialsError, TokenError
+
+settings = config.get_settings()
+USERS: Dict[str, str] = {}
+
+
+def _hash(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+
+async def register_user(email: str, password: str) -> None:
+    if len(password) < settings.password_min_length:
+        raise InvalidCredentialsError("Password does not meet policy")
+    checks = [any(c.islower() for c in password), any(c.isupper() for c in password), any(c.isdigit() for c in password)]
+    if not all(checks):
+        raise InvalidCredentialsError("Password does not meet policy")
+    USERS[email] = _hash(password)
+
+
+async def authenticate_user(email: str, password: str) -> bool:
+    stored = USERS.get(email)
+    if not stored or stored != _hash(password):
+        raise InvalidCredentialsError("Invalid email or password")
+    return True
+
+
+async def create_access_token(subject: str) -> str:
+    expire = datetime.utcnow() + timedelta(minutes=settings.access_token_ttl_minutes)
+    try:
+        return jwt.encode({"sub": subject, "exp": expire}, settings.secret_key, algorithm="HS256")
+    except jwt.PyJWTError as exc:  # pragma: no cover - library failure
+        raise TokenError("Could not create access token") from exc
+
+
+async def create_refresh_token(subject: str) -> str:
+    expire = datetime.utcnow() + timedelta(minutes=settings.refresh_token_ttl_minutes)
+    try:
+        return jwt.encode({"sub": subject, "exp": expire}, settings.secret_key, algorithm="HS256")
+    except jwt.PyJWTError as exc:  # pragma: no cover - library failure
+        raise TokenError("Could not create refresh token") from exc
+
+
+async def decode_token(token: str) -> str:
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+        return payload["sub"]
+    except jwt.PyJWTError as exc:
+        raise TokenError("Invalid token") from exc

--- a/postman/auth.postman_collection.json
+++ b/postman/auth.postman_collection.json
@@ -1,0 +1,50 @@
+{
+  "info": {
+    "name": "AgentFlow Auth",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Register",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"Password1\"\n}"
+        },
+        "url": {"raw": "{{baseUrl}}/auth/register", "host": ["{{baseUrl}}"], "path": ["auth", "register"]}
+      }
+    },
+    {
+      "name": "Login",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"email\": \"user@example.com\",\n  \"password\": \"Password1\"\n}"
+        },
+        "url": {"raw": "{{baseUrl}}/auth/login", "host": ["{{baseUrl}}"], "path": ["auth", "login"]}
+      }
+    },
+    {
+      "name": "Refresh",
+      "request": {
+        "method": "POST",
+        "header": [
+          {"key": "Content-Type", "value": "application/json"}
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"refresh_token\": \"{{refresh_token}}\"\n}"
+        },
+        "url": {"raw": "{{baseUrl}}/auth/refresh", "host": ["{{baseUrl}}"], "path": ["auth", "refresh"]}
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,14 @@ dependencies = [
   "alembic>=1.13",
   "psycopg[binary]>=3.2",
   "httpx>=0.27",
-    "r2r>=0.1.0",
-    "loguru>=0.7.2",
-    "cryptography>=42.0.0",
-    "pytest>=7.4",
-    "pytest-asyncio>=0.23",
-    "respx>=0.20"
-  ]
+  "r2r>=0.1.0",
+  "loguru>=0.7.2",
+  "cryptography>=42.0.0",
+  "pytest>=7.4",
+  "pytest-asyncio>=0.23",
+  "respx>=0.20",
+  "pyjwt",
+]
 
 [tool.uv]
 # If using uv, this section helps accelerate installs

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -1,0 +1,143 @@
+import os
+import pathlib
+import sys
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+import types
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from apps.api.app import config
+
+mock_ai = types.ModuleType("pydantic_ai")
+
+
+class DummyAgent:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.settings = None
+
+    async def run(self, prompt: str):  # pragma: no cover - stub
+        class R:
+            output_text = ""
+
+        return R()
+
+
+class DummyModelSettings:
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
+
+mock_ai.Agent = DummyAgent
+models_mod = types.ModuleType("pydantic_ai.models")
+models_mod.ModelSettings = DummyModelSettings
+sys.modules["pydantic_ai"] = mock_ai
+sys.modules["pydantic_ai.models"] = models_mod
+
+mock_psycopg = types.ModuleType("psycopg")
+
+
+class DummyConn:
+    async def execute(self, *args: object, **kwargs: object) -> None:
+        return None
+
+    async def close(self) -> None:  # pragma: no cover - stub
+        return None
+
+
+class DummyAsyncConnection:
+    @staticmethod
+    async def connect(dsn: str) -> DummyConn:  # pragma: no cover - stub
+        return DummyConn()
+
+
+mock_psycopg.AsyncConnection = DummyAsyncConnection
+sys.modules["psycopg"] = mock_psycopg
+
+from apps.api.app.services import auth as auth_service
+from apps.api.app.main import app
+
+config.get_settings.cache_clear()
+
+
+@pytest.mark.asyncio
+async def test_register_and_login() -> None:
+    auth_service.USERS.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/auth/register",
+            json={"email": "a@b.com", "password": "Password1"},
+        )
+        assert resp.status_code == 201
+        resp = await ac.post(
+            "/auth/login",
+            json={"email": "a@b.com", "password": "Password1"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "access_token" in data and "refresh_token" in data
+
+
+@pytest.mark.asyncio
+async def test_register_bad_password() -> None:
+    auth_service.USERS.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/auth/register",
+            json={"email": "a@b.com", "password": "short"},
+        )
+        assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_login_invalid_credentials() -> None:
+    auth_service.USERS.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/auth/register",
+            json={"email": "a@b.com", "password": "Password1"},
+        )
+        resp = await ac.post(
+            "/auth/login",
+            json={"email": "a@b.com", "password": "WrongPass1"},
+        )
+        assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_refresh() -> None:
+    auth_service.USERS.clear()
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.post(
+            "/auth/register",
+            json={"email": "a@b.com", "password": "Password1"},
+        )
+        login = await ac.post(
+            "/auth/login",
+            json={"email": "a@b.com", "password": "Password1"},
+        )
+        refresh_token = login.json()["refresh_token"]
+        resp = await ac.post("/auth/refresh", json={"refresh_token": refresh_token})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["access_token"] and data["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_invalid_token() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/auth/refresh", json={"refresh_token": "bad"})
+        assert resp.status_code == 401

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -7,13 +7,15 @@ from httpx import ASGITransport, AsyncClient
 import types
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
-from apps.api.app import config
 
 os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
 os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
 os.environ.setdefault("OPENAI_API_KEY", "test")
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+
+from apps.api.app import config
+
 config.get_settings.cache_clear()
 mock_ai = types.ModuleType("pydantic_ai")
 class DummyAgent:


### PR DESCRIPTION
## Summary
- implement JWT access and refresh token endpoints with registration
- enforce password policy and token/session TTL via settings
- add audit middleware logging auth events and provide Postman collection

## Testing
- `pytest tests/api/test_auth.py tests/api/test_health.py`

------
https://chatgpt.com/codex/tasks/task_e_68a55c76b11083228ddfe8d51596e349