### PR TITLE
feat: add caching and settings core modules

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -1,24 +1,3 @@
-from functools import lru_cache
+"""Backward-compatible settings import."""
 
-from pydantic_settings import BaseSettings, SettingsConfigDict
-
-
-class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
-    app_name: str = "AgentFlow API"
-    secret_key: str
-    openapi_url: str = "/openapi.json"
-    database_url: str
-    redis_url: str
-    qdrant_url: str
-    r2r_base_url: str = "http://localhost:7272"
-    r2r_api_key: str | None = None
-    log_level: str = "INFO"
-    password_min_length: int = 8
-    access_token_ttl_minutes: int = 15
-    refresh_token_ttl_minutes: int = 60 * 24
-
-
-@lru_cache()
-def get_settings() -> Settings:
-    return Settings()
+from .core.settings import Settings, get_settings

--- a/apps/api/app/core/__init__.py
+++ b/apps/api/app/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core utilities for AgentFlow API."""
+

--- a/apps/api/app/core/cache.py
+++ b/apps/api/app/core/cache.py
@@ -1,0 +1,66 @@
+"""Async Redis cache with retry logic."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from redis.asyncio import Redis
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from ..exceptions import CacheError
+from .settings import get_settings
+
+
+class Cache:
+    """Wrapper around Redis with resilience."""
+
+    def __init__(self, client: Redis, default_ttl: int = 60) -> None:
+        self.client = client
+        self.default_ttl = default_ttl
+
+    @retry(
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+        stop=stop_after_attempt(3),
+        reraise=True,
+    )
+    async def get(self, key: str) -> Optional[str]:
+        """Retrieve a value from cache."""
+
+        try:
+            return await self.client.get(key)
+        except Exception as exc:  # noqa: BLE001
+            raise CacheError(f"get failed: {exc}") from exc
+
+    @retry(
+        retry=retry_if_exception_type(Exception),
+        wait=wait_exponential(multiplier=0.5, min=0.5, max=2),
+        stop=stop_after_attempt(3),
+        reraise=True,
+    )
+    async def set(self, key: str, value: Any, ttl: int | None = None) -> None:
+        """Store a value in cache."""
+
+        try:
+            await self.client.set(key, value, ex=ttl or self.default_ttl)
+        except Exception as exc:  # noqa: BLE001
+            raise CacheError(f"set failed: {exc}") from exc
+
+
+_cache: Cache | None = None
+
+
+def get_cache() -> Cache:
+    """Return a singleton cache instance."""
+
+    global _cache
+    if _cache is None:
+        settings = get_settings()
+        client = Redis.from_url(settings.redis_url, decode_responses=True)
+        _cache = Cache(client)
+    return _cache

--- a/apps/api/app/core/settings.py
+++ b/apps/api/app/core/settings.py
@@ -1,0 +1,31 @@
+"""Application settings loaded from environment variables."""
+
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Pydantic settings for core configuration."""
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    app_name: str = "AgentFlow API"
+    secret_key: str
+    openapi_url: str = "/openapi.json"
+    database_url: str
+    redis_url: str
+    qdrant_url: str
+    r2r_base_url: str = "http://localhost:7272"
+    r2r_api_key: str | None = None
+    log_level: str = "INFO"
+    password_min_length: int = 8
+    access_token_ttl_minutes: int = 15
+    refresh_token_ttl_minutes: int = 60 * 24
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return cached application settings."""
+
+    return Settings()

--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -39,3 +39,7 @@ class InvalidCredentialsError(AuthenticationError):
 
 class TokenError(AuthenticationError):
     """Raised when token generation or validation fails."""
+
+
+class CacheError(AgentFlowError):
+    """Raised when cache operations fail."""

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -2,7 +2,7 @@ from fastapi import FastAPI
 
 from .config import get_settings
 from .middleware import AuditMiddleware
-from .routers import agents, auth, health, memory, rag
+from .routers import agents, auth, cache_examples, health, memory, rag
 from .utils.logging import setup_logging
 
 settings = get_settings()
@@ -16,3 +16,4 @@ app.include_router(memory.router, prefix="/memory", tags=["memory"])
 app.include_router(rag.router, prefix="/rag", tags=["rag"])
 app.include_router(agents.router, prefix="/agents", tags=["agents"])
 app.include_router(health.router)
+app.include_router(cache_examples.router, tags=["cache"])

--- a/apps/api/app/routers/cache_examples.py
+++ b/apps/api/app/routers/cache_examples.py
@@ -1,0 +1,49 @@
+"""Example routes demonstrating caching and idempotent POST."""
+
+import asyncio
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from pydantic import BaseModel
+
+from ..core.cache import Cache, get_cache
+from ..exceptions import CacheError
+
+router = APIRouter()
+
+
+class Item(BaseModel):
+    key: str
+    value: str
+
+
+@router.get("/cache/{key}")
+async def cached_get(key: str, cache: Cache = Depends(get_cache)) -> dict:
+    """Return data using Redis caching."""
+
+    try:
+        cached = await cache.get(key)
+        if cached is not None:
+            return {"key": key, "value": cached, "cached": True}
+        await asyncio.sleep(0.2)
+        value = f"value-for-{key}"
+        await cache.set(key, value)
+        return {"key": key, "value": value, "cached": False}
+    except CacheError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/cache/items", status_code=status.HTTP_201_CREATED)
+async def cached_post(
+    item: Item,
+    idempotency_key: str = Header(..., alias="Idempotency-Key"),
+    cache: Cache = Depends(get_cache),
+) -> dict:
+    """Idempotent item creation using cache."""
+
+    try:
+        existing = await cache.get(idempotency_key)
+        if existing is not None:
+            return {"id": idempotency_key, "value": existing, "cached": True}
+        await cache.set(idempotency_key, item.value)
+        return {"id": idempotency_key, "value": item.value, "cached": False}
+    except CacheError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,8 @@ dependencies = [
   "pytest-asyncio>=0.23",
   "respx>=0.20",
   "pyjwt",
+  "tenacity>=8.2",
+  "fakeredis>=2.23",
 ]
 
 [tool.uv]

--- a/tests/api/test_cache_examples.py
+++ b/tests/api/test_cache_examples.py
@@ -1,0 +1,56 @@
+import os
+import pathlib
+import sys
+import time
+
+import fakeredis.aioredis
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from apps.api.app import config
+from apps.api.app.core.cache import Cache, get_cache
+from apps.api.app.main import app
+
+config.get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def override_cache() -> None:
+    fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
+    app.dependency_overrides[get_cache] = lambda: Cache(fake)
+    yield
+    app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_cached_get_under_100ms() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.get("/cache/foo")
+        start = time.perf_counter()
+        resp = await ac.get("/cache/foo")
+        duration = (time.perf_counter() - start) * 1000
+        assert resp.status_code == 200
+        assert resp.json()["cached"] is True
+        assert duration < 100
+
+
+@pytest.mark.asyncio
+async def test_idempotent_post() -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        headers = {"Idempotency-Key": "abc"}
+        payload = {"key": "k1", "value": "v1"}
+        first = await ac.post("/cache/items", json=payload, headers=headers)
+        assert first.status_code == 201
+        second = await ac.post("/cache/items", json=payload, headers=headers)
+        assert second.status_code == 201
+        assert second.json()["cached"] is True


### PR DESCRIPTION
## Summary
- add Pydantic settings module under `core`
- implement Redis cache with Tenacity retries and new example routes
- test cached GET and idempotent POST with cache hit under 100ms

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a55ed7077c83228bd297ccd9739043