### PR TITLE
chore: pin fastapi for r2r compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.115.12
+fastapi==0.115.12  # pinned for r2r compatibility
 uvicorn[standard]==0.35.0
 python-dotenv==1.1.1
 pydantic==2.11.7


### PR DESCRIPTION
## Summary
- pin FastAPI to 0.115.12 for R2R compatibility
- reinstall dependencies and confirm FastAPI and R2R versions

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5d8e6588c832280fe859eb21c6c46