### PR TITLE
Add hosted Mem0 API key validation

### DIFF
--- a/apps/api/app/memory/service.py
+++ b/apps/api/app/memory/service.py
@@ -17,13 +17,22 @@ except ModuleNotFoundError:  # pragma: no cover
 
 MEM0_MODE = os.getenv("MEM0_MODE", "oss")
 if Memory is not None and MemoryClient is not None:
-    try:
-        if MEM0_MODE == "hosted":
-            _backend = MemoryClient(api_key=os.getenv("MEM0_API_KEY"))
-        else:
+    if MEM0_MODE == "hosted":
+        api_key = os.getenv("MEM0_API_KEY")
+        if not api_key:
+            raise MemoryServiceError("MEM0_API_KEY is required for hosted mode")
+        try:
+            _backend = MemoryClient(api_key=api_key)
+        except Exception:  # pragma: no cover
+            _backend = None
+    else:
+        try:
             _backend = Memory.from_config(
                 {
-                    "vector_store": {"provider": "qdrant", "config": {"host": "localhost", "port": 6333}},
+                    "vector_store": {
+                        "provider": "qdrant",
+                        "config": {"host": "localhost", "port": 6333},
+                    },
                     "llm": {
                         "provider": "openai",
                         "config": {
@@ -41,8 +50,8 @@ if Memory is not None and MemoryClient is not None:
                     "version": "v1.1",
                 }
             )
-    except Exception:  # pragma: no cover
-        _backend = None
+        except Exception:  # pragma: no cover
+            _backend = None
 else:  # pragma: no cover
     _backend = None
 

--- a/tests/services/test_memory_init.py
+++ b/tests/services/test_memory_init.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import types
+import pytest
+
+from apps.api.app.memory import service as memory_service_module
+from apps.api.app.memory.exceptions import MemoryServiceError
+
+
+@pytest.mark.asyncio
+async def test_hosted_mode_initialization_success(monkeypatch) -> None:
+    monkeypatch.setenv("MEM0_MODE", "hosted")
+    monkeypatch.setenv("MEM0_API_KEY", "testkey")
+
+    class DummyMemoryClient:
+        def __init__(self, api_key: str) -> None:  # pragma: no cover - simple stub
+            self.api_key = api_key
+    dummy_mem0 = types.SimpleNamespace(Memory=object(), MemoryClient=DummyMemoryClient)
+    monkeypatch.setitem(sys.modules, "mem0", dummy_mem0)
+    importlib.reload(memory_service_module)
+    assert isinstance(memory_service_module._backend, DummyMemoryClient)
+
+    monkeypatch.delenv("MEM0_MODE", raising=False)
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+    monkeypatch.delitem(sys.modules, "mem0", raising=False)
+    importlib.reload(memory_service_module)
+
+
+@pytest.mark.asyncio
+async def test_hosted_mode_initialization_missing_key(monkeypatch) -> None:
+    monkeypatch.setenv("MEM0_MODE", "hosted")
+    monkeypatch.delenv("MEM0_API_KEY", raising=False)
+
+    class DummyMemoryClient:
+        def __init__(self, api_key: str) -> None:  # pragma: no cover - simple stub
+            self.api_key = api_key
+
+    dummy_mem0 = types.SimpleNamespace(Memory=object(), MemoryClient=DummyMemoryClient)
+    monkeypatch.setitem(sys.modules, "mem0", dummy_mem0)
+    with pytest.raises(MemoryServiceError):
+        importlib.reload(memory_service_module)
+
+    monkeypatch.delenv("MEM0_MODE", raising=False)
+    monkeypatch.delitem(sys.modules, "mem0", raising=False)
+    importlib.reload(memory_service_module)


### PR DESCRIPTION
## Summary
- ensure `MEM0_API_KEY` is present when initializing hosted Mem0 backend
- add tests for hosted memory service initialization success and failure

## Testing
- `pytest tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5e0c89c6c832287b1e191f65f92c9