### PR TITLE
Add router error handling and tests

### DIFF
--- a/apps/api/app/routers/agents.py
+++ b/apps/api/app/routers/agents.py
@@ -1,10 +1,17 @@
-from fastapi import APIRouter, Depends
-from ..dependencies import require_roles, User
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..dependencies import User, require_roles
+from ..exceptions import AgentFlowError
 from ..models.schemas import AgentPrompt
 from ..services.agents import run_agent
 
 router = APIRouter()
 
+
 @router.post("/run", summary="Run agent")
 async def run(payload: AgentPrompt, user: User = Depends(require_roles(["user"]))):
-    return {"result": await run_agent(payload.prompt)}
+    try:
+        result = await run_agent(payload.prompt)
+        return {"result": result}
+    except AgentFlowError as exc:  # pragma: no cover - error path
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/apps/api/app/routers/rag.py
+++ b/apps/api/app/routers/rag.py
@@ -1,10 +1,16 @@
-from fastapi import APIRouter, Depends
-from ..dependencies import require_roles, User
+from fastapi import APIRouter, Depends, HTTPException
+
+from ..dependencies import User, require_roles
+from ..exceptions import R2RServiceError
 from ..models.schemas import RAGQuery
 from ..services.rag import rag
 
 router = APIRouter()
 
+
 @router.post("/", summary="Run RAG search")
 async def run_rag(payload: RAGQuery, user: User = Depends(require_roles(["user"]))):
-    return await rag(payload.query, use_kg=payload.use_kg, limit=payload.limit)
+    try:
+        return await rag(payload.query, use_kg=payload.use_kg, limit=payload.limit)
+    except R2RServiceError as exc:  # pragma: no cover - error path
+        raise HTTPException(status_code=502, detail=str(exc)) from exc

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,0 +1,56 @@
+import os
+import pathlib
+import sys
+import types
+
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+# Minimal environment configuration for FastAPI app
+os.environ.setdefault("DATABASE_URL", "postgresql://localhost/test")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+
+# Stub pydantic_ai to avoid heavy dependency during tests
+mock_ai = types.ModuleType("pydantic_ai")
+
+
+class DummyAgent:
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        self.settings = None
+
+    async def run(self, prompt: str):  # pragma: no cover - stub
+        class R:
+            output_text = ""
+
+        return R()
+
+
+mock_ai.Agent = DummyAgent
+models_mod = types.ModuleType("pydantic_ai.models")
+
+
+class DummyModelSettings:
+    def __init__(self, **kwargs: object) -> None:
+        pass
+
+
+models_mod.ModelSettings = DummyModelSettings
+sys.modules["pydantic_ai"] = mock_ai
+sys.modules["pydantic_ai.models"] = models_mod
+
+from apps.api.app.dependencies import User, get_current_user
+from apps.api.app.main import app
+
+
+@pytest.fixture(autouse=True)
+def override_user() -> None:
+    async def fake_get_current_user() -> User:
+        return User(sub="u1", roles=["user"])
+
+    app.dependency_overrides[get_current_user] = fake_get_current_user
+    yield
+    app.dependency_overrides.clear()

--- a/tests/api/test_agents_router.py
+++ b/tests/api/test_agents_router.py
@@ -1,0 +1,32 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apps.api.app.exceptions import AgentFlowError
+from apps.api.app.main import app
+from apps.api.app.routers import agents as agents_router
+
+
+@pytest.mark.asyncio
+async def test_run_agent_success(monkeypatch) -> None:
+    async def fake_run_agent(prompt: str) -> str:
+        return "ok"
+
+    monkeypatch.setattr(agents_router, "run_agent", fake_run_agent)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/agents/run", json={"prompt": "hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"result": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_failure(monkeypatch) -> None:
+    async def fake_run_agent(prompt: str) -> str:
+        raise AgentFlowError("boom")
+
+    monkeypatch.setattr(agents_router, "run_agent", fake_run_agent)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/agents/run", json={"prompt": "fail"})
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "boom"

--- a/tests/api/test_rag_router.py
+++ b/tests/api/test_rag_router.py
@@ -1,0 +1,32 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from apps.api.app.exceptions import R2RServiceError
+from apps.api.app.main import app
+from apps.api.app.routers import rag as rag_router
+
+
+@pytest.mark.asyncio
+async def test_run_rag_success(monkeypatch) -> None:
+    async def fake_rag(query: str, use_kg: bool = True, limit: int = 25) -> dict:
+        return {"results": []}
+
+    monkeypatch.setattr(rag_router, "rag", fake_rag)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/rag/", json={"query": "hi", "use_kg": True, "limit": 5})
+    assert resp.status_code == 200
+    assert resp.json() == {"results": []}
+
+
+@pytest.mark.asyncio
+async def test_run_rag_failure(monkeypatch) -> None:
+    async def fake_rag(query: str, use_kg: bool = True, limit: int = 25) -> dict:
+        raise R2RServiceError("fail")
+
+    monkeypatch.setattr(rag_router, "rag", fake_rag)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/rag/", json={"query": "bad", "use_kg": True, "limit": 5})
+    assert resp.status_code == 502
+    assert resp.json()["detail"] == "fail"


### PR DESCRIPTION
## Summary
- wrap agent execution in AgentFlowError handler and return HTTP 500
- convert R2R service errors to HTTP 502
- add API tests for agents and rag routers

## Testing
- `pytest tests/api/test_agents_router.py tests/api/test_rag_router.py`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a5e79b0d0c83228345d0047e097000