### PR TITLE
test: enable memory and seed tests

### DIFF
--- a/tests/api/test_memory_api.py
+++ b/tests/api/test_memory_api.py
@@ -2,10 +2,7 @@ import os
 import pathlib
 import sys
 import types
-from typing import List
 import pytest
-
-pytest.skip("API tests not yet supported", allow_module_level=True)
 
 from httpx import AsyncClient, ASGITransport
 

--- a/tests/db/test_seeds.py
+++ b/tests/db/test_seeds.py
@@ -1,7 +1,5 @@
 import pytest
 
-pytest.skip("DB seed tests not yet supported", allow_module_level=True)
-
 from sqlalchemy import select
 
 from apps.api.app.db.models import Organization, Role, User


### PR DESCRIPTION
## Summary
- remove module-level skips so memory API and DB seed tests run
- cover MemoryService add/search routes and seed workflow

## Testing
- `pytest --maxfail=1 --disable-warnings --cov=apps/api/app/memory tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5ed288e148322a61f22c5bfee1f04