### PR TITLE
feat(auth): add refresh token rotation

### DIFF
--- a/apps/api/app/routers/auth.py
+++ b/apps/api/app/routers/auth.py
@@ -23,17 +23,23 @@ async def login(credentials: LoginRequest) -> TokenResponse:
         await auth_service.authenticate_user(credentials.email, credentials.password)
         access = await auth_service.create_access_token(credentials.email)
         refresh = await auth_service.create_refresh_token(credentials.email)
+        await auth_service.store_refresh_token(refresh, credentials.email)
         return TokenResponse(access_token=access, refresh_token=refresh)
     except InvalidCredentialsError as exc:
         raise HTTPException(status_code=401, detail=str(exc))
+    except TokenError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
 
 
 @router.post("/refresh", response_model=TokenResponse)
 async def refresh(token: RefreshRequest) -> TokenResponse:
     try:
         subject = await auth_service.decode_token(token.refresh_token)
+        await auth_service.verify_refresh_token(token.refresh_token)
         access = await auth_service.create_access_token(subject)
-        refresh_token = await auth_service.create_refresh_token(subject)
-        return TokenResponse(access_token=access, refresh_token=refresh_token)
+        new_refresh = await auth_service.create_refresh_token(subject)
+        await auth_service.store_refresh_token(new_refresh, subject)
+        await auth_service.revoke_refresh_token(token.refresh_token)
+        return TokenResponse(access_token=access, refresh_token=new_refresh)
     except TokenError as exc:
         raise HTTPException(status_code=401, detail=str(exc))


### PR DESCRIPTION
## Summary
- add Redis-backed refresh token store with TTL
- rotate refresh tokens and revoke old ones on use
- test refresh token rotation to prevent replay attacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5f91c0260832293b3d89c65433cc0