### PR TITLE
feat(auth): add Redis token blacklist and logout endpoint

### DIFF
--- a/apps/api/app/services/token_store.py
+++ b/apps/api/app/services/token_store.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import jwt
+
+from .. import config
+from ..core.cache import get_cache
+from ..exceptions import CacheError, TokenError
+
+settings = config.get_settings()
+
+
+def _refresh_key(token: str) -> str:
+    return f"refresh:{token}"
+
+
+def _blacklist_key(token: str) -> str:
+    return f"blacklist:{token}"
+
+
+def _expires_in(token: str) -> int:
+    try:
+        payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+    except jwt.PyJWTError as exc:
+        raise TokenError("Invalid token") from exc
+    exp = datetime.fromtimestamp(payload["exp"])
+    return max(int((exp - datetime.utcnow()).total_seconds()), 0)
+
+
+async def store_refresh_token(token: str, subject: str) -> None:
+    cache = get_cache()
+    ttl = settings.refresh_token_ttl_minutes * 60
+    try:
+        await cache.set(_refresh_key(token), subject, ttl=ttl)
+    except CacheError as exc:  # pragma: no cover - network failure
+        raise TokenError("Could not store refresh token") from exc
+
+
+async def verify_refresh_token(token: str) -> str:
+    cache = get_cache()
+    try:
+        subject = await cache.get(_refresh_key(token))
+    except CacheError as exc:  # pragma: no cover - network failure
+        raise TokenError("Could not verify refresh token") from exc
+    if not subject:
+        raise TokenError("Invalid refresh token")
+    return subject
+
+
+async def blacklist_refresh_token(token: str) -> None:
+    cache = get_cache()
+    ttl = _expires_in(token)
+    try:
+        await cache.set(_blacklist_key(token), "1", ttl=ttl)
+    except CacheError as exc:  # pragma: no cover - network failure
+        raise TokenError("Could not blacklist token") from exc
+
+
+async def is_refresh_token_blacklisted(token: str) -> bool:
+    cache = get_cache()
+    try:
+        return bool(await cache.get(_blacklist_key(token)))
+    except CacheError as exc:  # pragma: no cover - network failure
+        raise TokenError("Could not verify token blacklist") from exc
+
+
+async def revoke_refresh_token(token: str) -> None:
+    cache = get_cache()
+    try:
+        await cache.client.delete(_refresh_key(token))
+        await blacklist_refresh_token(token)
+    except Exception as exc:  # pragma: no cover - network failure
+        raise TokenError("Could not revoke refresh token") from exc


### PR DESCRIPTION
## Summary
- manage refresh token persistence and blacklist in Redis
- block refresh requests using blacklisted tokens and expose `/auth/logout`
- cover logout and blacklist rejection in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb44b5308322b107a6b41a509962