### PR TITLE
feat(auth): add reset and me endpoints

### DIFF
--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -1,4 +1,5 @@
 """Pydantic models for authentication."""
+
 from pydantic import BaseModel, EmailStr
 
 
@@ -19,3 +20,15 @@ class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
+
+
+class ResetRequest(BaseModel):
+    email: EmailStr
+
+
+class ResetResponse(BaseModel):
+    reset_token: str
+
+
+class UserInfo(BaseModel):
+    email: EmailStr

--- a/apps/api/app/services/auth.py
+++ b/apps/api/app/services/auth.py
@@ -94,3 +94,15 @@ async def decode_token(token: str) -> str:
         return payload["sub"]
     except jwt.PyJWTError as exc:
         raise TokenError("Invalid token") from exc
+
+
+async def generate_reset_token(email: str) -> str:
+    if email not in USERS:
+        raise InvalidCredentialsError("User not found")
+    return uuid4().hex
+
+
+async def get_user_info(email: str) -> dict[str, str]:
+    if email not in USERS:
+        raise InvalidCredentialsError("User not found")
+    return {"email": email}


### PR DESCRIPTION
## Summary
- add password reset endpoint with token generation
- expose `/auth/me` to validate access tokens and return user info
- cover new auth endpoints with tests

## Testing
- `python -m black apps/api/app/routers/auth.py apps/api/app/models/auth.py apps/api/app/services/auth.py tests/api/test_auth.py`
- `pytest tests/api/test_auth.py::test_password_reset_and_me tests/api/test_auth.py::test_me_unauthorized tests/api/test_auth.py::test_reset_unknown_user`


------
https://chatgpt.com/codex/tasks/task_e_68a5fe18f188832293cb7abb8398da2e