### PR TITLE
feat: add otp-based login

### DIFF
--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -41,5 +41,9 @@ class TokenError(AuthenticationError):
     """Raised when token generation or validation fails."""
 
 
+class OTPError(AuthenticationError):
+    """Raised when one-time password validation fails."""
+
+
 class CacheError(AgentFlowError):
     """Raised when cache operations fail."""

--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -9,7 +9,7 @@ class UserCreate(BaseModel):
 
 
 class LoginRequest(UserCreate):
-    pass
+    otp_code: str
 
 
 class RefreshRequest(BaseModel):
@@ -32,3 +32,8 @@ class ResetResponse(BaseModel):
 
 class UserInfo(BaseModel):
     email: EmailStr
+
+
+class RegisterResponse(BaseModel):
+    otp_secret: str
+    status: str = "ok"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "pyjwt",
   "tenacity>=8.2",
   "fakeredis>=2.23",
+  "pyotp>=2.9",
 ]
 
 [tool.uv]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ respx==0.22.0
 pyjwt==2.10.1
 tenacity==9.1.2
 fakeredis==2.31.0
+pyotp==2.9.0


### PR DESCRIPTION
## Summary
- generate TOTP secrets on registration and require OTP code on login
- add custom OTPError and service helpers for TOTP validation
- cover OTP success and failure scenarios in tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a60cf51de483228d2127bd5e0bc4f5