### PR TITLE
feat: add correlation id middleware

### DIFF
--- a/apps/api/app/middleware.py
+++ b/apps/api/app/middleware.py
@@ -1,8 +1,11 @@
-"""FastAPI middleware for audit logging."""
+"""FastAPI middleware for audit logging and correlation IDs."""
+
 from __future__ import annotations
 
 import json
 import time
+import uuid
+from contextlib import suppress
 
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -10,20 +13,31 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 
+class MiddlewareError(Exception):
+    """Custom exception for middleware errors."""
+
+
 class AuditMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next) -> Response:  # type: ignore[override]
+        correlation_id = str(uuid.uuid4())
+        request.state.correlation_id = correlation_id
         body = await request.body()
         request._body = body
         start = time.time()
-        response = await call_next(request)
+        try:
+            response = await call_next(request)
+        except Exception as exc:  # pragma: no cover - passthrough
+            logger.error(
+                "middleware_error", correlation_id=correlation_id, error=str(exc)
+            )
+            raise MiddlewareError("Request processing failed") from exc
         duration = (time.time() - start) * 1000
         event = "auth" if request.url.path.startswith("/auth") else "request"
         email = None
         if event == "auth":
-            try:
+            with suppress(Exception):  # pragma: no cover - best effort
                 email = json.loads(body.decode()).get("email")
-            except Exception:  # pragma: no cover - best effort
-                email = None
+            response.headers["X-Correlation-ID"] = correlation_id
         logger.info(
             "audit",
             event=event,
@@ -32,5 +46,6 @@ class AuditMiddleware(BaseHTTPMiddleware):
             status=response.status_code,
             email=email,
             duration_ms=round(duration, 2),
+            correlation_id=correlation_id,
         )
         return response

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -2,10 +2,11 @@ import os
 import pathlib
 import sys
 import types
+import uuid
 
 import fakeredis.aioredis
 import pytest
-from httpx import ASGITransport, AsyncClient
+from httpx import ASGITransport, AsyncClient, Response
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -15,13 +16,13 @@ os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("OPENAI_API_KEY", "test")
 
+import pyotp
+
 from apps.api.app import config
 from apps.api.app.core.cache import Cache
 from apps.api.app.main import app
 from apps.api.app.services import auth as auth_service
 from apps.api.app.services import token_store
-import pyotp
-
 
 # Stub heavy dependencies
 mock_ai = types.ModuleType("pydantic_ai")
@@ -72,6 +73,11 @@ sys.modules["psycopg"] = mock_psycopg
 config.get_settings.cache_clear()
 
 
+def assert_correlation_id(resp: Response) -> None:
+    assert "X-Correlation-ID" in resp.headers
+    uuid.UUID(resp.headers["X-Correlation-ID"])
+
+
 @pytest.fixture(autouse=True)
 def override_cache(monkeypatch: pytest.MonkeyPatch) -> None:
     fake = fakeredis.aioredis.FakeRedis(decode_responses=True)
@@ -89,6 +95,7 @@ async def test_register_and_login() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 201
         secret = resp.json()["otp_secret"]
         code = pyotp.TOTP(secret).now()
@@ -96,6 +103,7 @@ async def test_register_and_login() -> None:
             "/auth/login",
             json={"email": "a@b.com", "password": "Password1!", "otp_code": code},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 200
         data = resp.json()
         assert "access_token" in data and "refresh_token" in data
@@ -110,19 +118,24 @@ async def test_refresh_rotation() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(reg)
         secret = reg.json()["otp_secret"]
         code = pyotp.TOTP(secret).now()
         login = await ac.post(
             "/auth/login",
             json={"email": "a@b.com", "password": "Password1!", "otp_code": code},
         )
+        assert_correlation_id(login)
         token1 = login.json()["refresh_token"]
         first = await ac.post("/auth/refresh", json={"refresh_token": token1})
+        assert_correlation_id(first)
         assert first.status_code == 200
         token2 = first.json()["refresh_token"]
         replay = await ac.post("/auth/refresh", json={"refresh_token": token1})
+        assert_correlation_id(replay)
         assert replay.status_code == 401
         second = await ac.post("/auth/refresh", json={"refresh_token": token2})
+        assert_correlation_id(second)
         assert second.status_code == 200
 
 
@@ -135,16 +148,20 @@ async def test_logout_blacklists_token() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(reg)
         secret = reg.json()["otp_secret"]
         code = pyotp.TOTP(secret).now()
         login = await ac.post(
             "/auth/login",
             json={"email": "a@b.com", "password": "Password1!", "otp_code": code},
         )
+        assert_correlation_id(login)
         token = login.json()["refresh_token"]
         resp = await ac.post("/auth/logout", json={"refresh_token": token})
+        assert_correlation_id(resp)
         assert resp.status_code == 200
         rejected = await ac.post("/auth/refresh", json={"refresh_token": token})
+        assert_correlation_id(rejected)
         assert rejected.status_code == 401
 
 
@@ -153,6 +170,7 @@ async def test_refresh_invalid_token() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.post("/auth/refresh", json={"refresh_token": "bad"})
+        assert_correlation_id(resp)
         assert resp.status_code == 401
 
 
@@ -165,12 +183,14 @@ async def test_login_invalid_credentials() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(reg)
         secret = reg.json()["otp_secret"]
         code = pyotp.TOTP(secret).now()
         resp = await ac.post(
             "/auth/login",
             json={"email": "a@b.com", "password": "WrongPass1!", "otp_code": code},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 401
 
 
@@ -179,15 +199,17 @@ async def test_login_invalid_otp() -> None:
     auth_service.USERS.clear()
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        await ac.post(
+        reg = await ac.post(
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(reg)
         wrong = "000000"
         resp = await ac.post(
             "/auth/login",
             json={"email": "a@b.com", "password": "Password1!", "otp_code": wrong},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 401
 
 
@@ -200,6 +222,7 @@ async def test_register_password_too_short() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "short"},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 400
 
 
@@ -212,6 +235,7 @@ async def test_register_password_missing_uppercase() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "password1!"},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 400
 
 
@@ -224,6 +248,7 @@ async def test_register_password_banned() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "password"},
         )
+        assert_correlation_id(resp)
         assert resp.status_code == 400
 
 
@@ -236,8 +261,10 @@ async def test_password_reset_and_me() -> None:
             "/auth/register",
             json={"email": "a@b.com", "password": "Password1!"},
         )
+        assert_correlation_id(reg)
         secret = reg.json()["otp_secret"]
         reset = await ac.post("/auth/reset", json={"email": "a@b.com"})
+        assert_correlation_id(reset)
         assert reset.status_code == 200
         token = reset.json()["reset_token"]
         assert token
@@ -246,8 +273,10 @@ async def test_password_reset_and_me() -> None:
             "/auth/login",
             json={"email": "a@b.com", "password": "Password1!", "otp_code": code},
         )
+        assert_correlation_id(login)
         access = login.json()["access_token"]
         me = await ac.get("/auth/me", headers={"Authorization": f"Bearer {access}"})
+        assert_correlation_id(me)
         assert me.status_code == 200
         assert me.json()["email"] == "a@b.com"
 
@@ -257,6 +286,7 @@ async def test_me_unauthorized() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/auth/me")
+        assert_correlation_id(resp)
         assert resp.status_code == 401
 
 
@@ -266,4 +296,5 @@ async def test_reset_unknown_user() -> None:
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.post("/auth/reset", json={"email": "a@b.com"})
+        assert_correlation_id(resp)
         assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- attach per-request correlation IDs via middleware
- expose correlation IDs in auth response headers and logs
- test auth endpoints for correlation IDs

## Testing
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a60ff965648322b58765d3f36be5f4