### PR TITLE
feat: add auth provider with token management

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/node": "^20.11.30",
         "@types/react": "^18.2.48",
+        "@types/react-dom": "^18.2.18",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.35",
         "tailwindcss": "^3.4.1",
@@ -793,6 +794,16 @@
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/acorn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "ts-node --esm lib/api.test.ts"
+    "test": "ts-node --esm lib/api.test.ts && ts-node --esm providers/auth-provider.test.ts"
   },
   "dependencies": {
     "next": "latest",
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@types/react": "^18.2.48",
     "@types/node": "^20.11.30",
+    "@types/react-dom": "^18.2.18",
     "typescript": "^5.4.0",
     "tailwindcss": "^3.4.1",
     "postcss": "^8.4.35",

--- a/frontend/providers/auth-provider.test.ts
+++ b/frontend/providers/auth-provider.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AuthProvider, { useAuth } from './auth-provider.ts';
+import type { AuthContextValue } from './auth-provider.ts';
+
+// type check export
+let _ctxType: AuthContextValue | null = null;
+_ctxType = _ctxType;
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+
+const storage: Record<string, string> = {};
+(global as any).localStorage = {
+  getItem: (k: string) => (k in storage ? storage[k] : null),
+  setItem: (k: string, v: string) => {
+    storage[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete storage[k];
+  },
+};
+
+const responses: Record<string, any> = {
+  '/auth/login': { access_token: 'access1', refresh_token: 'refresh1' },
+  '/auth/refresh': { access_token: 'access2', refresh_token: 'refresh2' },
+  '/auth/logout': { status: 'ok' },
+};
+
+(global as any).fetch = async (url: string, init?: RequestInit) => {
+  const path = url.replace(/^.*\/auth/, '/auth');
+  const body = responses[path];
+  return new Response(JSON.stringify(body), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+
+async function testContextMethods() {
+  let ctx: AuthContextValue | undefined;
+  function Test() {
+    ctx = useAuth();
+    return null;
+  }
+  renderToStaticMarkup(
+    React.createElement(AuthProvider, null, React.createElement(Test, null)),
+  );
+  assert.ok(ctx?.login);
+  assert.ok(ctx?.logout);
+  assert.ok(ctx?.refresh);
+}
+
+async function testTokenStorage() {
+  let ctx: AuthContextValue | undefined;
+  function Test() {
+    ctx = useAuth();
+    ctx.login({ email: 'a@b.com', password: 'x' });
+    return null;
+  }
+  renderToStaticMarkup(
+    React.createElement(AuthProvider, null, React.createElement(Test, null)),
+  );
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(storage.accessToken, 'access1');
+  assert.equal(storage.refreshToken, 'refresh1');
+  await ctx!.logout();
+  assert.equal(storage.accessToken, undefined);
+  assert.equal(storage.refreshToken, undefined);
+}
+
+(async () => {
+  await testContextMethods();
+  await testTokenStorage();
+  console.log('All tests passed');
+})();

--- a/frontend/providers/auth-provider.ts
+++ b/frontend/providers/auth-provider.ts
@@ -1,0 +1,165 @@
+import React, { createContext, useContext, useEffect, useRef, useState } from 'react';
+import ApiClient from '../lib/api.ts';
+import { z } from 'zod';
+
+class AuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+interface LoginPayload { email: string; password: string; otpCode?: string }
+interface TokenResponse { access_token: string; refresh_token: string }
+
+export interface AuthContextValue {
+  accessToken: string | null;
+  refreshToken: string | null;
+  login: (payload: LoginPayload) => Promise<void>;
+  logout: () => Promise<void>;
+  refresh: () => Promise<void>;
+  error: string | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+  otpCode: z.string().min(1).optional(),
+});
+
+function parseJwt(token: string): { exp?: number } {
+  try {
+    const base64 = token.split('.')[1];
+    const json = atob(base64.replace(/-/g, '+').replace(/_/g, '/'));
+    return JSON.parse(json);
+  } catch {
+    return {};
+  }
+}
+
+function isExpired(token: string): boolean {
+  const { exp } = parseJwt(token);
+  return exp ? Date.now() >= exp * 1000 - 60000 : false;
+}
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const clientRef = useRef(new ApiClient());
+
+  useEffect(() => {
+    const at = localStorage.getItem('accessToken');
+    const rt = localStorage.getItem('refreshToken');
+    if (at && rt) {
+      setAccessToken(at);
+      setRefreshToken(rt);
+    }
+  }, []);
+
+  async function saveTokens(tokens: TokenResponse): Promise<void> {
+    setAccessToken(tokens.access_token);
+    setRefreshToken(tokens.refresh_token);
+    localStorage.setItem('accessToken', tokens.access_token);
+    localStorage.setItem('refreshToken', tokens.refresh_token);
+  }
+
+  const login = async (payload: LoginPayload): Promise<void> => {
+    setLoading(true);
+    try {
+      const data = loginSchema.parse(payload);
+      const tokens = (await (clientRef.current as any).request(
+        '/auth/login',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+        },
+      )) as TokenResponse;
+      await saveTokens(tokens);
+      setError(null);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed';
+      setError(message);
+      throw new AuthError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const refresh = async (): Promise<void> => {
+    if (!refreshToken) throw new AuthError('Missing refresh token');
+    try {
+      const tokens = (await (clientRef.current as any).request(
+        '/auth/refresh',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ refresh_token: refreshToken }),
+        },
+      )) as TokenResponse;
+      await saveTokens(tokens);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Refresh failed';
+      setError(message);
+      throw new AuthError(message);
+    }
+  };
+
+  const logout = async (): Promise<void> => {
+    if (!refreshToken) {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      setAccessToken(null);
+      setRefreshToken(null);
+      return;
+    }
+    try {
+      await (clientRef.current as any).request('/auth/logout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refreshToken }),
+      });
+    } catch (err) {
+      // ignore logout errors
+    } finally {
+      localStorage.removeItem('accessToken');
+      localStorage.removeItem('refreshToken');
+      setAccessToken(null);
+      setRefreshToken(null);
+    }
+  };
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      if (accessToken && isExpired(accessToken)) {
+        refresh().catch(() => logout());
+      }
+    }, 60000);
+    return () => clearInterval(id);
+  }, [accessToken, refreshToken]);
+
+  const value: AuthContextValue = {
+    accessToken,
+    refreshToken,
+    login,
+    logout,
+    refresh,
+    error,
+    loading,
+  };
+
+  return React.createElement(AuthContext.Provider, { value }, children);
+};
+
+export const useAuth = (): AuthContextValue => {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new AuthError('AuthContext not found');
+  return ctx;
+};
+
+export default AuthProvider;


### PR DESCRIPTION
## Summary
- implement React authentication context with JWT storage and refresh handling
- add unit tests for auth provider and token persistence
- wire up test scripts and typings

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: requires interactive setup)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6207902988322a4ac0865368ccd73