### PR TITLE
feat(frontend): add root layout with auth and navigation

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,10 +1,2 @@
 import './globals.css';
-import type { ReactNode } from 'react';
-
-export default function RootLayout({ children }: { children: ReactNode }) {
-  return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
-  );
-}
+export { default } from './root-layout.ts';

--- a/frontend/app/root-layout.test.ts
+++ b/frontend/app/root-layout.test.ts
@@ -1,0 +1,44 @@
+process.env.NEXT_PUBLIC_API_BASE_URL = "http://localhost";
+
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import RootLayout from './root-layout.ts';
+import { useAuth, type AuthContextValue } from '../providers/auth-provider.ts';
+
+const storage: Record<string, string> = {};
+(global as any).localStorage = {
+  getItem: (k: string) => (k in storage ? storage[k] : null),
+  setItem: (k: string, v: string) => {
+    storage[k] = v;
+  },
+  removeItem: (k: string) => {
+    delete storage[k];
+  },
+};
+
+(global as any).fetch = async () =>
+  new Response(
+    JSON.stringify({ access_token: 'access1', refresh_token: 'refresh1' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+async function testLayout() {
+  let ctx: AuthContextValue | undefined;
+  function Child() {
+    ctx = useAuth();
+    ctx.login({ email: 'a@b.com', password: 'x' });
+    return React.createElement('div', null, 'child');
+  }
+  const html = renderToStaticMarkup(
+    React.createElement(RootLayout, null, React.createElement(Child, null)),
+  );
+  assert.ok(html.includes('<nav'));
+  await new Promise((r) => setTimeout(r, 0));
+  assert.equal(storage.accessToken, 'access1');
+}
+
+(async () => {
+  await testLayout();
+  console.log('RootLayout tests passed');
+})();

--- a/frontend/app/root-layout.ts
+++ b/frontend/app/root-layout.ts
@@ -1,0 +1,30 @@
+import React, { type ReactNode } from 'react';
+import { AuthProvider } from '../providers/auth-provider.ts';
+import { ThemeProvider } from '../providers/theme-provider.ts';
+import Navigation from '../components/layout/navigation.ts';
+import { ErrorBoundary } from '../components/layout/error-boundary.ts';
+
+export default function RootLayout({ children }: { children: ReactNode }): JSX.Element {
+  return React.createElement(
+    'html',
+    { lang: 'en' },
+    React.createElement(
+      'body',
+      null,
+      React.createElement(
+        ErrorBoundary,
+        null,
+        React.createElement(
+          ThemeProvider,
+          null,
+          React.createElement(
+            AuthProvider,
+            null,
+            React.createElement(Navigation, null),
+            children,
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/frontend/components/layout/error-boundary.test.ts
+++ b/frontend/components/layout/error-boundary.test.ts
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ErrorBoundary } from './error-boundary.ts';
+
+const boundary = new ErrorBoundary({
+  children: React.createElement('div', null, 'ok'),
+  fallback: React.createElement('div', null, 'failed'),
+});
+boundary.state = { hasError: true } as any;
+const html = renderToStaticMarkup(boundary.render() as React.ReactElement);
+assert.ok(html.includes('failed'));
+
+console.log('ErrorBoundary tests passed');

--- a/frontend/components/layout/error-boundary.ts
+++ b/frontend/components/layout/error-boundary.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import React from 'react';
+
+export class LayoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'LayoutError';
+  }
+}
+
+interface Props {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error): void {
+    console.error(new LayoutError(error.message));
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return this.props.fallback || React.createElement('div', null, 'Something went wrong');
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/components/layout/navigation.test.ts
+++ b/frontend/components/layout/navigation.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Navigation from './navigation.ts';
+
+const html = renderToStaticMarkup(React.createElement(Navigation));
+assert.ok(html.includes('Home'));
+assert.ok(html.includes('Dashboard'));
+assert.ok(html.includes('md:flex'));
+assert.ok(html.includes('md:hidden'));
+
+console.log('Navigation tests passed');

--- a/frontend/components/layout/navigation.ts
+++ b/frontend/components/layout/navigation.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link.js';
+
+interface NavItem {
+  href: string;
+  label: string;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: '/', label: 'Home' },
+  { href: '/dashboard', label: 'Dashboard' },
+];
+
+export default function Navigation(): JSX.Element {
+  const [open, setOpen] = useState(false);
+  function handleToggle(): void {
+    setOpen((v) => !v);
+  }
+  const list = NAV_ITEMS.map((item) =>
+    React.createElement(
+      'li',
+      { key: item.href, className: 'p-2' },
+      React.createElement(Link, { href: item.href }, item.label),
+    ),
+  );
+  return React.createElement(
+    'nav',
+    { className: 'border-b' },
+    React.createElement(
+      'div',
+      { className: 'flex items-center justify-between p-4' },
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          'aria-label': 'Toggle navigation',
+          onClick: handleToggle,
+          className: 'md:hidden',
+        },
+        '☰',
+      ),
+      React.createElement(
+        'ul',
+        { className: `${open ? 'block' : 'hidden'} md:flex md:gap-4` },
+        ...list,
+      ),
+    ),
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "ts-node --esm lib/api.test.ts && ts-node --esm providers/auth-provider.test.ts"
+    "test": "ts-node --esm lib/api.test.ts && ts-node --esm providers/auth-provider.test.ts && ts-node --esm providers/theme-provider.test.ts && ts-node --esm components/layout/error-boundary.test.ts && ts-node --esm components/layout/navigation.test.ts && ts-node --esm app/root-layout.test.ts"
   },
   "dependencies": {
     "next": "latest",

--- a/frontend/providers/theme-provider.test.ts
+++ b/frontend/providers/theme-provider.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ThemeProvider, useTheme } from './theme-provider.ts';
+
+const storage: Record<string, string> = {};
+(global as any).localStorage = {
+  getItem: (k: string) => (k in storage ? storage[k] : null),
+  setItem: (k: string, v: string) => {
+    storage[k] = v;
+  },
+};
+(global as any).document = { documentElement: { classList: { toggle: () => {} } } };
+
+let saved: string | null = null;
+function Test() {
+  const { toggle } = useTheme();
+  toggle();
+  saved = localStorage.getItem('theme');
+  return null;
+}
+
+renderToStaticMarkup(React.createElement(ThemeProvider, null, React.createElement(Test, null)));
+assert.equal(saved, 'dark');
+
+console.log('ThemeProvider tests passed');

--- a/frontend/providers/theme-provider.ts
+++ b/frontend/providers/theme-provider.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Theme = 'light' | 'dark';
+
+export interface ThemeContextValue {
+  theme: Theme;
+  toggle: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem('theme') as Theme | null;
+      if (stored === 'dark' || stored === 'light') {
+        setTheme(stored);
+        document.documentElement.classList.toggle('dark', stored === 'dark');
+      }
+    } catch {
+      /* ignore storage errors */
+    }
+  }, []);
+
+  function toggle(): void {
+    try {
+      const next: Theme = theme === 'light' ? 'dark' : 'light';
+      document.documentElement.classList.toggle('dark', next === 'dark');
+      localStorage.setItem('theme', next);
+      setTheme(next);
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+
+  const value: ThemeContextValue = { theme, toggle };
+  return React.createElement(ThemeContext.Provider, { value }, children);
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error('ThemeContext not found');
+  }
+  return ctx;
+};
+
+export default ThemeProvider;


### PR DESCRIPTION
## Summary
- add RootLayout with AuthProvider, ThemeProvider, navigation, and error boundary
- implement responsive navigation and theme context
- cover layout, navigation, theme, and error components with tests

## Testing
- `npm test`
- `npm run type-check`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a6233129008322aaf5482e099a9151