### PR TITLE
feat(frontend): add user registration page

### DIFF
--- a/frontend/app/(auth)/register/page.test.ts
+++ b/frontend/app/(auth)/register/page.test.ts
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { registerSchema, registerUser, type RegisterValues, RegisterError } from './utils.ts';
+
+async function run(): Promise<void> {
+  assert.throws(() => registerSchema.parse({ email: 'x', password: 'a', confirmPassword: 'b' }));
+  const ok: RegisterValues = { email: 'a@b.com', password: 'password', confirmPassword: 'password' };
+  const goodClient = { request: async () => ({}) } as any;
+  await registerUser(ok, goodClient);
+  const badClient = { request: async () => { throw new Error('fail'); } } as any;
+  await assert.rejects(() => registerUser(ok, badClient), RegisterError);
+}
+
+run().then(() => console.log('Register page tests passed'));

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import ApiClient from '../../../lib/api.ts';
+import { registerSchema, type RegisterValues, registerUser, RegisterError } from './utils.ts';
+
+export default function RegisterPage(): JSX.Element {
+  const router = useRouter();
+  const clientRef = useRef<any>(new ApiClient());
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<RegisterValues>({ resolver: zodResolver(registerSchema) });
+
+  const onSubmit = async (values: RegisterValues): Promise<void> => {
+    setLoading(true);
+    setError(null);
+    try {
+      await registerUser(values, clientRef.current);
+      setSuccess('Registration successful');
+      setTimeout(() => router.push('/login'), 1500);
+    } catch (err) {
+      const message = err instanceof RegisterError ? err.message : 'Registration failed';
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <input type="email" {...register('email')} placeholder="Email" />
+      {errors.email && <div>{errors.email.message}</div>}
+      <input type="password" {...register('password')} placeholder="Password" />
+      {errors.password && <div>{errors.password.message}</div>}
+      <input type="password" {...register('confirmPassword')} placeholder="Confirm Password" />
+      {errors.confirmPassword && <div>{errors.confirmPassword.message}</div>}
+      {error && <div>{error}</div>}
+      {success && <div>{success}</div>}
+      <button type="submit" disabled={loading} className="border px-4 py-2">
+        {loading ? 'Loading...' : 'Register'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/(auth)/register/utils.ts
+++ b/frontend/app/(auth)/register/utils.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const registerSchema = z
+  .object({
+    email: z.string().email(),
+    password: z.string().min(8),
+    confirmPassword: z.string().min(8),
+  })
+  .refine((d) => d.password === d.confirmPassword, {
+    message: 'Passwords must match',
+    path: ['confirmPassword'],
+  });
+
+export type RegisterValues = z.infer<typeof registerSchema>;
+
+export class RegisterError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RegisterError';
+  }
+}
+
+type Client = {
+  request: (
+    endpoint: string,
+    init?: RequestInit & { timeoutMs?: number; retries?: number },
+  ) => Promise<unknown>;
+};
+
+export async function registerUser(
+  values: RegisterValues,
+  client: Client,
+): Promise<void> {
+  const data = registerSchema.parse(values);
+  try {
+    await client.request('/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: data.email, password: data.password }),
+      timeoutMs: 5000,
+      retries: 3,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Registration failed';
+    throw new RegisterError(message);
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/login/page.test.ts\""
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/login/page.test.ts\" && tsx \"app/(auth)/register/page.test.ts\""
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",


### PR DESCRIPTION
## Summary
- add registration page with react-hook-form and zod validation
- submit registration via ApiClient with retry/timeout and error handling
- include tests for registration flow and update test script

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run type-check`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62d3a55d48322bb6ba03a22dd82d4