### PR TITLE
feat(frontend): add registration page with validation and tests

### DIFF
--- a/frontend/app/(auth)/register/page.test.ts
+++ b/frontend/app/(auth)/register/page.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { registerSchema, registerUser, type RegisterValues, RegistrationError } from './utils.ts';
+
+async function run() {
+  assert.throws(() => registerSchema.parse({ email: 'bad', password: '12345678', confirmPassword: '12345678' }));
+  assert.throws(
+    () => registerSchema.parse({ email: 'a@b.com', password: '12345678', confirmPassword: '87654321' }),
+    /Passwords do not match/,
+  );
+  const ok: RegisterValues = { email: 'a@b.com', password: '12345678', confirmPassword: '12345678' };
+  const clientOk = { request: async () => ({}) } as any;
+  await registerUser(clientOk, ok);
+  const clientFail = { request: async () => { throw new Error('fail'); } } as any;
+  await assert.rejects(() => registerUser(clientFail, ok), RegistrationError);
+}
+
+run().then(() => console.log('Register page tests passed'));

--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import ApiClient from '../../../lib/api.ts';
+import { registerSchema, type RegisterValues, registerUser, RegistrationError } from './utils.ts';
+
+export default function RegisterPage(): JSX.Element {
+  const router = useRouter();
+  const clientRef = useRef(new ApiClient());
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<RegisterValues>({ resolver: zodResolver(registerSchema) });
+
+  const onSubmit = async (values: RegisterValues): Promise<void> => {
+    try {
+      await registerUser(clientRef.current, values);
+      setSuccess('Registration successful');
+      setTimeout(() => router.push('/login'), 1000);
+    } catch (err) {
+      const message = err instanceof RegistrationError ? err.message : 'Registration failed';
+      setError(message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <input type="email" {...register('email')} placeholder="Email" />
+      {errors.email && <div>{errors.email.message}</div>}
+      <input type="password" {...register('password')} placeholder="Password" />
+      {errors.password && <div>{errors.password.message}</div>}
+      <input type="password" {...register('confirmPassword')} placeholder="Confirm Password" />
+      {errors.confirmPassword && <div>{errors.confirmPassword.message}</div>}
+      {error && <div>{error}</div>}
+      {success && <div>{success}</div>}
+      <button type="submit" disabled={isSubmitting} className="border px-4 py-2">
+        {isSubmitting ? 'Loading...' : 'Register'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/app/(auth)/register/utils.ts
+++ b/frontend/app/(auth)/register/utils.ts
@@ -1,0 +1,46 @@
+import ApiClient from '../../../lib/api.ts';
+import { z } from 'zod';
+
+export class RegistrationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RegistrationError';
+  }
+}
+
+export const registerSchema = z
+  .object({
+    email: z.string().email(),
+    password: z.string().min(8),
+    confirmPassword: z.string().min(8),
+  })
+  .superRefine((data, ctx) => {
+    if (data.password !== data.confirmPassword) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['confirmPassword'],
+        message: 'Passwords do not match',
+      });
+    }
+  });
+
+export type RegisterValues = z.infer<typeof registerSchema>;
+
+export async function registerUser(
+  client: ApiClient,
+  values: RegisterValues,
+): Promise<void> {
+  const data = registerSchema.parse(values);
+  try {
+    await (client as any).request('/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: data.email, password: data.password }),
+      timeoutMs: 5000,
+      retries: 3,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Registration failed';
+    throw new RegistrationError(message);
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/login/page.test.ts\""
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/login/page.test.ts\" && tsx \"app/(auth)/register/page.test.ts\""
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",


### PR DESCRIPTION
## Summary
- add registration page using react-hook-form and Zod with password confirmation
- submit registration through ApiClient with timeout and retry handling
- cover registration flow with tests and wire into npm test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a62c0934b48322a10b502493a249f5