### PR TITLE
feat: add auth layout component

### DIFF
--- a/frontend/app/(auth)/layout.test.tsx
+++ b/frontend/app/(auth)/layout.test.tsx
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AuthLayout from './layout.tsx';
+
+async function run(): Promise<void> {
+  process.env.NEXT_PUBLIC_BRAND_NAME = 'AgentFlow';
+  const html = renderToStaticMarkup(
+    <AuthLayout>
+      <div>child</div>
+    </AuthLayout>,
+  );
+  assert.ok(html.includes('AgentFlow'));
+  assert.ok(html.includes('child'));
+
+  delete process.env.NEXT_PUBLIC_BRAND_NAME;
+  const html2 = renderToStaticMarkup(
+    <AuthLayout>
+      <div>child</div>
+    </AuthLayout>,
+  );
+  assert.ok(!html2.includes('AgentFlow'));
+}
+
+run().then(() => console.log('AuthLayout tests passed'));

--- a/frontend/app/(auth)/layout.tsx
+++ b/frontend/app/(auth)/layout.tsx
@@ -1,0 +1,22 @@
+import React, { Suspense, type ReactNode } from 'react';
+
+interface AuthLayoutProps {
+  children: ReactNode;
+}
+
+export default function AuthLayout({ children }: AuthLayoutProps): JSX.Element {
+  const brand = process.env.NEXT_PUBLIC_BRAND_NAME;
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Suspense fallback={<div>Loading...</div>}>
+        <div className="w-full max-w-md space-y-6">
+          {brand && (
+            <div className="text-center text-2xl font-semibold">{brand}</div>
+          )}
+          {children}
+        </div>
+      </Suspense>
+    </div>
+  );
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/login/page.test.ts\" && tsx \"app/(auth)/register/page.test.ts\""
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(auth)/login/page.test.ts\" && tsx \"app/(auth)/register/page.test.ts\""
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",


### PR DESCRIPTION
## Summary
- add AuthLayout for authentication pages with branding and Suspense support
- cover AuthLayout with unit tests and wire into npm test script

## Testing
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run type-check`
- `npm run test`
- `npm run build` *(fails: API base URL not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a6506ab594832287b5003e7e43c6cc