### PR TITLE
feat: improve registration form structure

### DIFF
--- a/frontend/app/(auth)/register/page.tsx
+++ b/frontend/app/(auth)/register/page.tsx
@@ -1,52 +1,67 @@
 'use client';
 
 import React, { useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { useForm, type FieldErrors, type UseFormRegister } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import ApiClient from '../../../lib/api.ts';
-import { registerSchema, type RegisterValues, registerUser, RegisterError } from './utils.ts';
+import {
+  registerSchema,
+  type RegisterValues,
+  registerUser,
+  RegisterError,
+  type Client,
+} from './utils.ts';
 
-export default function RegisterPage(): JSX.Element {
-  const router = useRouter();
-  const clientRef = useRef<any>(new ApiClient());
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm<RegisterValues>({ resolver: zodResolver(registerSchema) });
+interface FieldsProps {
+  register: UseFormRegister<RegisterValues>;
+  errors: FieldErrors<RegisterValues>;
+  status: { error: string | null; success: string | null };
+  loading: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+}
 
-  const onSubmit = async (values: RegisterValues): Promise<void> => {
-    setLoading(true);
-    setError(null);
-    try {
-      await registerUser(values, clientRef.current);
-      setSuccess('Registration successful');
-      setTimeout(() => router.push('/login'), 1500);
-    } catch (err) {
-      const message = err instanceof RegisterError ? err.message : 'Registration failed';
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  };
-
+function Fields({ register, errors, status, loading, onSubmit }: FieldsProps) {
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+    <form onSubmit={onSubmit} className="space-y-4">
       <input type="email" {...register('email')} placeholder="Email" />
       {errors.email && <div>{errors.email.message}</div>}
       <input type="password" {...register('password')} placeholder="Password" />
       {errors.password && <div>{errors.password.message}</div>}
       <input type="password" {...register('confirmPassword')} placeholder="Confirm Password" />
       {errors.confirmPassword && <div>{errors.confirmPassword.message}</div>}
-      {error && <div>{error}</div>}
-      {success && <div>{success}</div>}
+      {status.error && <div>{status.error}</div>}
+      {status.success && <div>{status.success}</div>}
       <button type="submit" disabled={loading} className="border px-4 py-2">
         {loading ? 'Loading...' : 'Register'}
       </button>
     </form>
   );
 }
+
+export default function RegisterPage(): JSX.Element {
+  const router = useRouter();
+  const clientRef = useRef<Client>(new ApiClient() as unknown as Client);
+  const [status, setStatus] = useState<{ error: string | null; success: string | null }>({ error: null, success: null });
+  const [loading, setLoading] = useState(false);
+  const { register, handleSubmit, formState: { errors } } = useForm<RegisterValues>({ resolver: zodResolver(registerSchema) });
+
+  const submit = async (values: RegisterValues): Promise<void> => {
+    setLoading(true); setStatus({ error: null, success: null });
+    try {
+      await registerUser(values, clientRef.current);
+      setStatus({ error: null, success: 'Registration successful' });
+      setTimeout(() => router.push('/login'), 1500);
+    } catch (err) {
+      const message = err instanceof RegisterError ? err.message : 'Registration failed';
+      setStatus({ error: message, success: null });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Fields register={register} errors={errors} status={status} loading={loading} onSubmit={handleSubmit(submit)} />
+  );
+}
+

--- a/frontend/app/(auth)/register/utils.ts
+++ b/frontend/app/(auth)/register/utils.ts
@@ -20,7 +20,7 @@ export class RegisterError extends Error {
   }
 }
 
-type Client = {
+export type Client = {
   request: (
     endpoint: string,
     init?: RequestInit & { timeoutMs?: number; retries?: number },


### PR DESCRIPTION
## Summary
- modularize registration form into reusable Fields component
- export Client type for register utility and use typed client reference

## Testing
- `npm run type-check`
- `npm test`
- `npm run test:coverage`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a704ccf81883228e4af384d91b8758