### PR TITLE
feat(frontend): add agents dashboard

### DIFF
--- a/frontend/app/(dashboard)/agents/layout.test.tsx
+++ b/frontend/app/(dashboard)/agents/layout.test.tsx
@@ -1,0 +1,14 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AgentsLayout from './layout.tsx';
+
+const html = renderToStaticMarkup(
+  <AgentsLayout>
+    <div>child</div>
+  </AgentsLayout>,
+);
+assert.ok(html.includes('Dashboard'));
+assert.ok(html.includes('Agents'));
+assert.ok(html.includes('child'));
+console.log('AgentsLayout tests passed');

--- a/frontend/app/(dashboard)/agents/layout.tsx
+++ b/frontend/app/(dashboard)/agents/layout.tsx
@@ -1,0 +1,25 @@
+import React, { type ReactNode } from 'react';
+import Link from 'next/link.js';
+import Navigation from '../../../components/layout/navigation.ts';
+
+interface AgentsLayoutProps {
+  children: ReactNode;
+}
+
+export default function AgentsLayout({ children }: AgentsLayoutProps): JSX.Element {
+  return (
+    <div>
+      <Navigation />
+      <nav aria-label="Breadcrumb" className="border-b p-4 text-sm">
+        <ol className="flex gap-2">
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+          <li>/</li>
+          <li>Agents</li>
+        </ol>
+      </nav>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/agents/page.test.tsx
+++ b/frontend/app/(dashboard)/agents/page.test.tsx
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import AgentsPage from './page.tsx';
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+(global as any).fetch = async () =>
+  new Response(
+    JSON.stringify([{ id: '1', name: 'A1' }]),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+(async () => {
+  const html = renderToStaticMarkup(await AgentsPage());
+  assert.ok(html.includes('A1'));
+  assert.ok(html.includes('/agents/1/edit'));
+  assert.ok(html.includes('/agents/1/test'));
+  console.log('AgentsPage tests passed');
+})();

--- a/frontend/app/(dashboard)/agents/page.tsx
+++ b/frontend/app/(dashboard)/agents/page.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Link from 'next/link.js';
+import ApiClient from '../../../lib/api.ts';
+import type { Agent } from '../../../lib/types.ts';
+
+class AgentsPageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentsPageError';
+  }
+}
+
+export default async function AgentsPage(): Promise<JSX.Element> {
+  const client = new ApiClient();
+  let agents: Agent[] = [];
+  try {
+    agents = await client.listAgents();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(new AgentsPageError(message));
+  }
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-semibold">Agents</h1>
+        <Link href="/agents/create" className="text-blue-600">
+          Create Agent
+        </Link>
+      </div>
+      <ul className="space-y-2">
+        {agents.map((a) => (
+          <li key={a.id} className="flex gap-4">
+            <Link href={`/agents/${a.id}/edit`}>{a.name}</Link>
+            <Link href={`/agents/${a.id}/test`} className="text-blue-600">
+              Test
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -17,7 +17,22 @@ function testMissingBaseUrl() {
   assert.throws(() => new ApiClient(), /API base URL not configured/);
 }
 
+async function testListAgents() {
+  resetEnv();
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+  (global as any).fetch = async () =>
+    new Response(
+      JSON.stringify([{ id: '1', name: 'A1' }]),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  const client = new ApiClient();
+  const agents = await client.listAgents();
+  assert.equal(agents[0].name, 'A1');
+}
+
 testInstantiation();
 testMissingBaseUrl();
-
-console.log('All tests passed');
+(async () => {
+  await testListAgents();
+  console.log('All tests passed');
+})();

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,4 +1,4 @@
-import type { MemoryItem, RagQuery, AgentPrompt } from './types.ts';
+import type { MemoryItem, RagQuery, AgentPrompt, Agent } from './types.ts';
 import { z } from 'zod';
 
 class ApiError extends Error {
@@ -29,6 +29,9 @@ const ragQuerySchema = z.object({
 const agentPromptSchema = z.object({
   prompt: z.string().min(1),
 });
+
+const agentSchema = z.object({ id: z.string(), name: z.string() });
+const agentsSchema = z.array(agentSchema);
 
 export class ApiClient {
   private baseUrl: string;
@@ -112,6 +115,18 @@ export class ApiClient {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
       });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        throw error;
+      }
+      throw new ApiError((error as Error).message);
+    }
+  }
+
+  async listAgents(): Promise<Agent[]> {
+    try {
+      const data = await this.request<unknown>('/agents');
+      return agentsSchema.parse(data);
     } catch (error) {
       if (error instanceof ApiError) {
         throw error;

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -17,3 +17,8 @@ export interface RagQuery {
 export interface AgentPrompt {
   prompt: string;
 }
+
+export interface Agent {
+  id: string;
+  name: string;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && jest",
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && jest",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- list agents with create/edit/test links
- add agents section layout with navigation and breadcrumbs
- support fetching agent list via API client

## Testing
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run type-check`
- `npm run test`
- `npm run test:coverage`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a70d41f4008322a7360943c78da296