### PR TITLE
feat(frontend): add agent run form with retries

### DIFF
--- a/frontend/app/(dashboard)/agents/create/page.test.tsx
+++ b/frontend/app/(dashboard)/agents/create/page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import AgentRunPage from './page.tsx';
+
+process.env.NEXT_PUBLIC_API_URL = 'http://localhost';
+
+describe('AgentRunPage', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('submits prompt and posts data', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ result: 'ok' }),
+    } as Response);
+    (global as any).fetch = fetchMock;
+    render(<AgentRunPage />);
+    fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: 'hi' } });
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost/agents/run',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: 'hi' }),
+        signal: expect.any(AbortSignal),
+      }),
+    ));
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('shows validation error for empty prompt', async () => {
+    const fetchMock = jest.fn();
+    (global as any).fetch = fetchMock;
+    render(<AgentRunPage />);
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+    await waitFor(() => expect(screen.getByText('Prompt is required')).toBeInTheDocument());
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('shows error message on request failure', async () => {
+    const fetchMock = jest.fn().mockRejectedValue(new Error('bad'));
+    (global as any).fetch = fetchMock;
+    render(<AgentRunPage />);
+    fireEvent.change(screen.getByLabelText(/prompt/i), { target: { value: 'fail' } });
+    fireEvent.click(screen.getByRole('button', { name: /run/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent('bad'));
+  });
+});
+

--- a/frontend/app/(dashboard)/agents/create/page.tsx
+++ b/frontend/app/(dashboard)/agents/create/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+
+// Mirror of AgentPrompt schema in apps/api/app/models/schemas.py
+interface AgentPrompt {
+  prompt: string;
+}
+
+class AgentRunError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentRunError';
+  }
+}
+
+const schema = z.object({ prompt: z.string().min(1, 'Prompt is required') });
+
+async function postAgentPrompt(
+  data: AgentPrompt,
+  { timeoutMs = 5000, retries = 3 }: { timeoutMs?: number; retries?: number } = {},
+): Promise<unknown> {
+  for (let attempt = 0; attempt < retries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/agents/run`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(data),
+          signal: controller.signal,
+        },
+      );
+      clearTimeout(timeout);
+      if (!res.ok) {
+        throw new AgentRunError(`Status ${res.status}`);
+      }
+      return await res.json();
+    } catch (err) {
+      clearTimeout(timeout);
+      if (attempt === retries - 1) {
+        const msg = err instanceof Error ? err.message : 'Unknown error';
+        throw new AgentRunError(msg);
+      }
+    }
+  }
+  throw new AgentRunError('Failed after retries');
+}
+
+export default function AgentRunPage(): JSX.Element {
+  const [error, setError] = useState<string | null>(null);
+  const { register, handleSubmit, formState: { errors } } = useForm<AgentPrompt>({ resolver: zodResolver(schema) });
+
+  const onSubmit = async (values: AgentPrompt): Promise<void> => {
+    try {
+      await postAgentPrompt(values);
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setError(msg);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" aria-describedby={error ? 'form-error' : undefined}>
+      <label htmlFor="prompt" className="block font-medium">Prompt</label>
+      <textarea
+        id="prompt"
+        {...register('prompt')}
+        aria-invalid={Boolean(errors.prompt)}
+        aria-describedby={errors.prompt ? 'prompt-error' : undefined}
+        className="w-full border p-2"
+      />
+      {errors.prompt && (
+        <div id="prompt-error" role="alert" aria-live="assertive" className="text-red-600">
+          {errors.prompt.message}
+        </div>
+      )}
+      {error && (
+        <div id="form-error" role="alert" aria-live="assertive" className="text-red-600">
+          {error}
+        </div>
+      )}
+      <button type="submit" className="border px-4 py-2">Run</button>
+    </form>
+  );
+}
+

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -9,6 +9,7 @@ const customJestConfig = {
   testMatch: [
     '<rootDir>/app/(auth)/login/page.test.tsx',
     '<rootDir>/app/(auth)/register/page.test.tsx',
+    '<rootDir>/app/(dashboard)/agents/create/page.test.tsx',
   ],
 };
 


### PR DESCRIPTION
## Summary
- add accessible agent run form with validation and API retries
- test agent run page and include in jest config

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a727fe41f0832281b5317898fddff6