### PR TITLE
feat: add agent edit page and update API client

### DIFF
--- a/frontend/app/(dashboard)/agents/[id]/edit/form.tsx
+++ b/frontend/app/(dashboard)/agents/[id]/edit/form.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import ApiClient from '../../../../../lib/api.ts';
+import type { Agent, AgentUpdate } from '../../../../../lib/types.ts';
+
+class AgentUpdateError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentUpdateError';
+  }
+}
+
+export default function AgentForm({ agent }: { agent: Agent }): JSX.Element {
+  const schema = z.object({ name: z.string().min(1, 'Name is required') });
+  const client = new ApiClient();
+  const [error, setError] = React.useState<string | null>(null);
+  const { register, handleSubmit, formState: { errors } } = useForm<AgentUpdate>({
+    resolver: zodResolver(schema),
+    defaultValues: { name: agent.name },
+  });
+  const onSubmit = async (values: AgentUpdate): Promise<void> => {
+    try {
+      await client.updateAgent(agent.id, values, { timeoutMs: 5000, retries: 3 });
+      setError(null);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setError(new AgentUpdateError(msg).message);
+    }
+  };
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" aria-describedby={error ? 'form-error' : undefined}>
+      <label htmlFor="name" className="block font-medium">Name</label>
+      <input
+        id="name"
+        defaultValue={agent.name}
+        {...register('name')}
+        aria-invalid={Boolean(errors.name)}
+        aria-describedby={errors.name ? 'name-error' : undefined}
+        className="w-full border p-2"
+      />
+      {errors.name && <div id="name-error" role="alert" aria-live="assertive" className="text-red-600">{errors.name.message}</div>}
+      {error && <div id="form-error" role="alert" aria-live="assertive" className="text-red-600">{error}</div>}
+      <button type="submit" className="border px-4 py-2">Save</button>
+    </form>
+  );
+}

--- a/frontend/app/(dashboard)/agents/[id]/edit/page.test.tsx
+++ b/frontend/app/(dashboard)/agents/[id]/edit/page.test.tsx
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Page from './page.tsx';
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+(global as any).fetch = async () =>
+  new Response(
+    JSON.stringify({ id: '1', name: 'Agent1' }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+
+(async () => {
+  const html = renderToStaticMarkup(await Page({ params: Promise.resolve({ id: '1' }) }));
+  assert.ok(html.includes('value="Agent1"'));
+  console.log('AgentEditPage tests passed');
+})();

--- a/frontend/app/(dashboard)/agents/[id]/edit/page.tsx
+++ b/frontend/app/(dashboard)/agents/[id]/edit/page.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import ApiClient from '../../../../../lib/api.ts';
+import type { Agent } from '../../../../../lib/types.ts';
+import AgentForm from './form.tsx';
+
+class AgentEditPageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'AgentEditPageError';
+  }
+}
+
+async function fetchAgent(id: string): Promise<Agent | null> {
+  const client = new ApiClient();
+  try {
+    return await client.getAgent(id, { timeoutMs: 5000, retries: 3 });
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    console.error(new AgentEditPageError(msg));
+    return null;
+  }
+}
+
+export default async function AgentEditPage({ params }: { params: Promise<{ id: string }> }): Promise<JSX.Element> {
+  const { id } = await params;
+  const agent = await fetchAgent(id);
+  if (!agent) {
+    return <div>Failed to load agent.</div>;
+  }
+  return <AgentForm agent={agent} />;
+}

--- a/frontend/lib/api.test.ts
+++ b/frontend/lib/api.test.ts
@@ -30,9 +30,41 @@ async function testListAgents() {
   assert.equal(agents[0].name, 'A1');
 }
 
+async function testGetAgent() {
+  resetEnv();
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+  (global as any).fetch = async () =>
+    new Response(
+      JSON.stringify({ id: '1', name: 'A1' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  const client = new ApiClient();
+  const agent = await client.getAgent('1');
+  assert.equal(agent.id, '1');
+}
+
+async function testUpdateAgent() {
+  resetEnv();
+  process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+  (global as any).fetch = async (_: string, options?: RequestInit) => {
+    const body = JSON.parse(options?.body as string);
+    assert.equal(options?.method, 'PATCH');
+    assert.equal(body.name, 'B1');
+    return new Response(
+      JSON.stringify({ id: '1', name: 'B1' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    );
+  };
+  const client = new ApiClient();
+  const agent = await client.updateAgent('1', { name: 'B1' });
+  assert.equal(agent.name, 'B1');
+}
+
 testInstantiation();
 testMissingBaseUrl();
 (async () => {
   await testListAgents();
+  await testGetAgent();
+  await testUpdateAgent();
   console.log('All tests passed');
 })();

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -22,3 +22,7 @@ export interface Agent {
   id: string;
   name: string;
 }
+
+export interface AgentUpdate {
+  name: string;
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --formatter-enabled=false --assist-enabled=false .",
     "format": "biome format .",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && jest",
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && jest",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add server-side agent edit page that fetches existing agent and renders client form
- extend API client with getAgent and updateAgent methods and type
- cover new functionality with tests and update scripts

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`
- `npm run test:coverage`
- `NEXT_PUBLIC_API_BASE_URL=http://localhost npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7296e97248322b6a5d93b7e07a3ef