### PR TITLE
feat: add memory browser and API support

### DIFF
--- a/frontend/app/(dashboard)/memory/layout.tsx
+++ b/frontend/app/(dashboard)/memory/layout.tsx
@@ -1,0 +1,25 @@
+import React, { type ReactNode } from 'react';
+import Link from 'next/link.js';
+import Navigation from '../../../components/layout/navigation.ts';
+
+interface MemoryLayoutProps {
+  children: ReactNode;
+}
+
+export default function MemoryLayout({ children }: MemoryLayoutProps): JSX.Element {
+  return (
+    <div>
+      <Navigation />
+      <nav aria-label="Breadcrumb" className="border-b p-4 text-sm">
+        <ol className="flex gap-2">
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+          <li>/</li>
+          <li>Memory</li>
+        </ol>
+      </nav>
+      <div className="p-4">{children}</div>
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/memory/page.test.tsx
+++ b/frontend/app/(dashboard)/memory/page.test.tsx
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import MemoryPage from './page.tsx';
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+
+(async () => {
+  const html = renderToStaticMarkup(<MemoryPage />);
+  assert.ok(html.includes('Dashboard'));
+  assert.ok(html.includes('Memory'));
+  console.log('MemoryPage tests passed');
+})();

--- a/frontend/app/(dashboard)/memory/page.tsx
+++ b/frontend/app/(dashboard)/memory/page.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Link from 'next/link.js';
+import MemoryBrowser from '../../../components/memory/memory-browser.tsx';
+
+export default function MemoryPage(): JSX.Element {
+  return (
+    <div className="space-y-4">
+      <nav aria-label="Breadcrumb" className="text-sm">
+        <ol className="flex gap-2">
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+          <li>/</li>
+          <li>Memory</li>
+        </ol>
+      </nav>
+      <MemoryBrowser />
+    </div>
+  );
+}

--- a/frontend/components/memory/memory-browser.test.tsx
+++ b/frontend/components/memory/memory-browser.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import MemoryBrowser from './memory-browser.tsx';
+
+const mockList = jest.fn();
+const mockSearch = jest.fn();
+const mockDelete = jest.fn();
+
+jest.mock('../../lib/api.ts', () =>
+  jest.fn().mockImplementation(() => ({
+    listMemoryItems: mockList,
+    searchMemoryItems: mockSearch,
+    updateMemoryItem: jest.fn(),
+    deleteMemoryItem: mockDelete,
+  })),
+);
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockSearch.mockReset();
+  mockDelete.mockReset();
+  mockList.mockResolvedValue([]);
+  mockSearch.mockResolvedValue([]);
+});
+
+test('renders and searches memory items', async () => {
+  mockList.mockResolvedValueOnce([{ id: '1', text: 'a' }]);
+  render(<MemoryBrowser />);
+  expect(await screen.findByText('a')).toBeInTheDocument();
+  fireEvent.change(screen.getByLabelText('Search'), { target: { value: 'b' } });
+  fireEvent.submit(screen.getByLabelText('Search').closest('form')!);
+  await waitFor(() => expect(mockSearch).toHaveBeenCalledWith({ q: 'b' }));
+});
+
+test('deletes an item', async () => {
+  mockList.mockResolvedValueOnce([{ id: '1', text: 'x' }]);
+  render(<MemoryBrowser />);
+  expect(await screen.findByText('x')).toBeInTheDocument();
+  fireEvent.click(screen.getByText('Delete'));
+  await waitFor(() => expect(mockDelete).toHaveBeenCalled());
+});

--- a/frontend/components/memory/memory-browser.tsx
+++ b/frontend/components/memory/memory-browser.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { z } from 'zod';
+import ApiClient from '../../lib/api.ts';
+import type { MemoryItem } from '../../lib/types.ts';
+
+class MemoryBrowserError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MemoryBrowserError';
+  }
+}
+
+const searchSchema = z.object({ q: z.string().optional() });
+const textSchema = z.object({ text: z.string().min(1) });
+
+async function loadItems(
+  client: ApiClient,
+  q: string,
+  setItems: React.Dispatch<React.SetStateAction<MemoryItem[]>>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  try {
+    const data = q ? await client.searchMemoryItems({ q }) : await client.listMemoryItems();
+    setItems(data);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Load failed';
+    setError(new MemoryBrowserError(msg).message);
+  }
+}
+
+async function editItem(
+  client: ApiClient,
+  id: string,
+  refresh: () => Promise<void>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  const input = prompt('New text');
+  if (input === null) return;
+  try {
+    const { text } = textSchema.parse({ text: input });
+    await client.updateMemoryItem(id, { text });
+    await refresh();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Update failed';
+    setError(new MemoryBrowserError(msg).message);
+  }
+}
+
+async function removeItem(
+  client: ApiClient,
+  id: string,
+  refresh: () => Promise<void>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  try {
+    await client.deleteMemoryItem(id);
+    await refresh();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Delete failed';
+    setError(new MemoryBrowserError(msg).message);
+  }
+}
+
+async function searchItems(
+  e: React.FormEvent,
+  q: string,
+  setQ: React.Dispatch<React.SetStateAction<string>>,
+  client: ApiClient,
+  setItems: React.Dispatch<React.SetStateAction<MemoryItem[]>>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+): Promise<void> {
+  e.preventDefault();
+  try {
+    const { q: query } = searchSchema.parse({ q });
+    setQ(query ?? '');
+    await loadItems(client, query ?? '', setItems, setError);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Search failed';
+    setError(new MemoryBrowserError(msg).message);
+  }
+}
+
+function renderItem(
+  item: MemoryItem,
+  client: ApiClient,
+  refresh: () => Promise<void>,
+  setError: React.Dispatch<React.SetStateAction<string | null>>,
+): JSX.Element {
+  return (
+    <li key={item.id} className="flex gap-2">
+      <span className="flex-1">{item.text}</span>
+      <button
+        type="button"
+        className="text-blue-600"
+        onClick={() => editItem(client, item.id!, refresh, setError)}
+      >
+        Edit
+      </button>
+      <button
+        type="button"
+        className="text-red-600"
+        onClick={() => removeItem(client, item.id!, refresh, setError)}
+      >
+        Delete
+      </button>
+    </li>
+  );
+}
+
+function SearchForm({
+  q,
+  setQ,
+  onSearch,
+}: {
+  q: string;
+  setQ: React.Dispatch<React.SetStateAction<string>>;
+  onSearch: (e: React.FormEvent) => void;
+}): JSX.Element {
+  return (
+    <form onSubmit={onSearch} className="flex gap-2">
+      <input
+        aria-label="Search"
+        className="border p-2"
+        value={q}
+        onChange={(e) => setQ(e.target.value)}
+      />
+      <button type="submit" className="bg-blue-500 px-3 py-2 text-white">
+        Search
+      </button>
+    </form>
+  );
+}
+
+export default function MemoryBrowser(): JSX.Element {
+  const client = new ApiClient();
+  const [q, setQ] = useState('');
+  const [items, setItems] = useState<MemoryItem[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const refresh = async () => loadItems(client, q, setItems, setError);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 5000);
+    return () => clearInterval(id);
+  }, [q]);
+
+  return (
+    <div className="space-y-4">
+      <SearchForm
+        q={q}
+        setQ={setQ}
+        onSearch={(e) => searchItems(e, q, setQ, client, setItems, setError)}
+      />
+      {error && <div className="text-red-600">{error}</div>}
+      <ul className="space-y-2">
+        {items.map((i) => renderItem(i, client, refresh, setError))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -11,6 +11,7 @@ const customJestConfig = {
     '<rootDir>/app/(auth)/register/page.test.tsx',
     '<rootDir>/app/(dashboard)/agents/create/page.test.tsx',
     '<rootDir>/components/agents/__tests__/*.test.ts?(x)',
+    '<rootDir>/components/memory/*.test.tsx',
   ],
 };
 

--- a/frontend/lib/types.ts
+++ b/frontend/lib/types.ts
@@ -6,8 +6,12 @@ export interface MemoryItem {
   scope?: MemoryScope;
   userId?: string;
   agentId?: string;
-  runId?: string;
-  metadata?: Record<string, unknown> | null;
+  sessionId?: string;
+  tags?: string[];
+  metadata?: Record<string, unknown>;
+  ttl?: number;
+  createdAt?: string;
+  expiresAt?: string | null;
 }
 
 export interface RAGQuery {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --formatter-enabled=false --assist-enabled=false .",
     "format": "biome format .",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && jest",
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- extend MemoryItem schema and API client with list, search, update and delete operations
- add MemoryBrowser component with search/edit/delete and polling
- expose memory browser page in dashboard with tests

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a73ab531408322af47e9247df6c582