### PR TITLE
feat: add memory streaming

### DIFF
--- a/apps/api/app/memory/exceptions.py
+++ b/apps/api/app/memory/exceptions.py
@@ -10,3 +10,11 @@ class MemoryNotFoundError(MemoryError):
 
 class MemoryServiceError(MemoryError):
     """Raised when memory backend operations fail."""
+
+
+class MemoryStreamError(MemoryError):
+    """Base error for memory streaming."""
+
+
+class MemoryStreamTimeoutError(MemoryStreamError):
+    """Raised when memory stream times out."""

--- a/apps/api/app/memory/models.py
+++ b/apps/api/app/memory/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Literal
 
 from pydantic import BaseModel, Field, validator
 
@@ -59,3 +59,10 @@ class MemoryItem(MemoryItemBase):
         if value is None and ttl is not None:
             return values["created_at"] + timedelta(seconds=ttl)
         return value
+
+
+class MemoryEvent(BaseModel):
+    """Event emitted when memory changes."""
+
+    action: Literal["created", "updated", "deleted"]
+    item: MemoryItem

--- a/tests/memory/test_stream.py
+++ b/tests/memory/test_stream.py
@@ -1,0 +1,28 @@
+import asyncio
+import os
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379/0")
+os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from apps.api.app.memory.models import MemoryItemCreate, MemoryScope
+from apps.api.app.memory.service import memory_service
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_events() -> None:
+    queue = memory_service.subscribe()
+    try:
+        await memory_service.add_item(
+            MemoryItemCreate(text="hello", scope=MemoryScope.GLOBAL)
+        )
+        event = await asyncio.wait_for(queue.get(), timeout=1)
+        assert event.action == "created"
+        assert event.item.text == "hello"
+    finally:
+        memory_service.unsubscribe(queue)
+


### PR DESCRIPTION
## Summary
- stream memory changes via SSE endpoint
- connect MemoryBrowser to refresh on server events
- test backend memory stream and frontend subscription logic

## Testing
- `pytest tests/memory/test_stream.py`
- `npx jest components/memory/memory-browser.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68a7401b0cbc83229e479628ae849e1a