### PR TITLE
feat: add memory, rag, and agent services

### DIFF
--- a/apps/api/app/routers/memory.py
+++ b/apps/api/app/routers/memory.py
@@ -17,7 +17,7 @@ from ..memory.exceptions import (
     MemoryStreamTimeoutError,
 )
 from ..memory.models import MemoryEvent, MemoryItem, MemoryItemCreate, MemoryItemUpdate, MemoryScope
-from ..memory.service import memory_service
+from ..services.memory import memory_service
 
 router = APIRouter()
 

--- a/apps/api/app/services/agents.py
+++ b/apps/api/app/services/agents.py
@@ -1,4 +1,9 @@
+"""Agent orchestration service."""
+
+from __future__ import annotations
+
 import asyncio
+from typing import Callable
 
 from pydantic_ai import Agent
 from pydantic_ai.models import ModelSettings
@@ -7,28 +12,46 @@ from tenacity import AsyncRetrying, stop_after_attempt, wait_exponential
 from ..config import get_settings
 from ..exceptions import AgentFlowError
 
-# Simple, typed agent you can extend
+
+class AgentService:
+    """Service wrapper around a pydantic-ai Agent with retry logic."""
+
+    def __init__(self, agent: Agent, settings_factory: Callable[[], object] = get_settings) -> None:
+        self.agent = agent
+        self._settings_factory = settings_factory
+
+    async def run_agent(self, prompt: str) -> str:
+        settings = self._settings_factory()
+        if not prompt or not prompt.strip():
+            raise AgentFlowError("Prompt must be a non-empty string")
+        try:
+            async for attempt in AsyncRetrying(
+                stop=stop_after_attempt(settings.agent_retry_max_attempts),
+                wait=wait_exponential(multiplier=settings.agent_retry_backoff_seconds),
+                reraise=True,
+            ):
+                with attempt:
+                    async with asyncio.timeout(settings.agent_run_timeout_seconds):
+                        result = await self.agent.run(prompt)
+                        return result.output_text
+        except Exception as exc:  # noqa: BLE001
+            raise AgentFlowError("Agent execution failed") from exc
+
+
 agent = Agent(
     "openai:gpt-4o",
     system_prompt="You are AgentFlow. Be concise, cite sources when available.",
 )
 agent.settings = ModelSettings(temperature=0.1, max_tokens=500)
 
+_service = AgentService(agent)
+
 
 async def run_agent(prompt: str) -> str:
-    settings = get_settings()
-    if not prompt or not prompt.strip():
-        raise AgentFlowError("Prompt must be a non-empty string")
+    """Compatibility wrapper for existing imports."""
 
-    try:
-        async for attempt in AsyncRetrying(
-            stop=stop_after_attempt(settings.agent_retry_max_attempts),
-            wait=wait_exponential(multiplier=settings.agent_retry_backoff_seconds),
-            reraise=True,
-        ):
-            with attempt:
-                async with asyncio.timeout(settings.agent_run_timeout_seconds):
-                    result = await agent.run(prompt)
-                    return result.output_text
-    except Exception as exc:  # noqa: BLE001
-        raise AgentFlowError("Agent execution failed") from exc
+    return await _service.run_agent(prompt)
+
+
+__all__ = ["AgentService", "agent", "run_agent"]
+

--- a/apps/api/app/services/rag.py
+++ b/apps/api/app/services/rag.py
@@ -1,27 +1,60 @@
+"""RAG service layer."""
+
+from __future__ import annotations
+
 import asyncio
 import os
+from typing import Optional
+
 from httpx import AsyncClient, HTTPError
+
 from ..exceptions import R2RServiceError
+
 
 R2R_BASE = os.getenv("R2R_BASE_URL", "http://localhost:7272")
 R2R_API_KEY = os.getenv("R2R_API_KEY", "")
 
+
+class RAGService:
+    """Service for interacting with the R2R retrieval API."""
+
+    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None) -> None:
+        self.base_url = base_url or R2R_BASE
+        self.api_key = api_key or R2R_API_KEY
+
+    async def query(self, query: str, *, use_kg: bool = True, limit: int = 25) -> dict:
+        if not query.strip():
+            raise ValueError("query cannot be empty")
+        payload = {
+            "query": query,
+            "rag_generation_config": {"model": "gpt-4o-mini", "temperature": 0.0},
+            "search_settings": {"use_hybrid_search": True, "use_kg_search": use_kg, "limit": limit},
+        }
+        headers = {"Authorization": f"Bearer {self.api_key}"} if self.api_key else {}
+        for attempt in range(3):
+            try:
+                async with AsyncClient(timeout=10) as client:
+                    resp = await client.post(
+                        f"{self.base_url}/api/retrieval/rag",
+                        json=payload,
+                        headers=headers,
+                    )
+                    resp.raise_for_status()
+                    return resp.json()
+            except HTTPError as exc:  # noqa: BLE001
+                if attempt == 2:
+                    raise R2RServiceError("R2R request failed") from exc
+                await asyncio.sleep(2**attempt)
+
+
+rag_service = RAGService()
+
+
 async def rag(query: str, use_kg: bool = True, limit: int = 25) -> dict:
-    if not query.strip():
-        raise ValueError("query cannot be empty")
-    payload = {
-        "query": query,
-        "rag_generation_config": {"model": "gpt-4o-mini", "temperature": 0.0},
-        "search_settings": {"use_hybrid_search": True, "use_kg_search": use_kg, "limit": limit},
-    }
-    headers = {"Authorization": f"Bearer {R2R_API_KEY}"} if R2R_API_KEY else {}
-    for attempt in range(3):
-        try:
-            async with AsyncClient(timeout=10) as client:
-                resp = await client.post(f"{R2R_BASE}/api/retrieval/rag", json=payload, headers=headers)
-                resp.raise_for_status()
-                return resp.json()
-        except HTTPError as exc:  # noqa: BLE001
-            if attempt == 2:
-                raise R2RServiceError("R2R request failed") from exc
-            await asyncio.sleep(2 ** attempt)
+    """Compatibility wrapper for existing imports."""
+
+    return await rag_service.query(query, use_kg=use_kg, limit=limit)
+
+
+__all__ = ["RAGService", "rag_service", "rag"]
+

--- a/tests/memory/test_stream.py
+++ b/tests/memory/test_stream.py
@@ -10,7 +10,7 @@ os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("OPENAI_API_KEY", "test")
 
 from apps.api.app.memory.models import MemoryItemCreate, MemoryScope
-from apps.api.app.memory.service import memory_service
+from apps.api.app.services.memory import memory_service
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_memory.py
+++ b/tests/services/test_memory.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime, timedelta, timezone
 
-from apps.api.app.memory.service import memory_service as mem_service
+from apps.api.app.services.memory import memory_service as mem_service
 from apps.api.app.memory.exceptions import MemoryNotFoundError, MemoryServiceError
 from apps.api.app.memory.models import (
     MemoryItemCreate,

--- a/tests/services/test_memory_init.py
+++ b/tests/services/test_memory_init.py
@@ -3,7 +3,7 @@ import sys
 import types
 import pytest
 
-from apps.api.app.memory import service as memory_service_module
+from apps.api.app.services import memory as memory_service_module
 from apps.api.app.memory.exceptions import MemoryServiceError
 
 


### PR DESCRIPTION
## Summary
- implement MemoryService with mem0 backend support and event streams
- add class-based RAGService with retries and input validation
- wrap pydantic-ai Agent in AgentService with retry/timeout logic
- update memory router and tests for new service layout

## Testing
- `ruff check apps/api/app/services/memory.py apps/api/app/services/rag.py apps/api/app/services/agents.py`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68a746359f7c83228033153b748f458d