### PR TITLE
feat: validate OpenAI API key during memory init

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,6 +272,8 @@ This document provides essential context for AI models interacting with this pro
 *   **Environment Configuration:**
     - Use environment-specific `.env` files (never commit `.env` with secrets)
     - Validate all required environment variables on application startup
+    - Required variables: `OPENAI_API_KEY`, `MEM0_API_KEY` (hosted mode),
+      `QDRANT_URL`, `QDRANT_PORT`, `POSTGRES_URL`
     - Use secure secret management systems in production (AWS Secrets Manager, Azure Key Vault)
 *   **Database Setup:**
     - PostgreSQL with connection pooling and SSL enabled

--- a/README.md
+++ b/README.md
@@ -374,6 +374,9 @@ LOG_LEVEL=INFO
 DEBUG=false
 ```
 
+> **Required:** `OPENAI_API_KEY` must be set for memory initialization. Use
+> `MEM0_API_KEY` when `MEM0_MODE=hosted`.
+
 ### Service Configuration
 
 <details>


### PR DESCRIPTION
## Summary
- ensure memory backend checks OPENAI_API_KEY and logs config errors
- add tests for missing/invalid OpenAI API key
- document required environment variables

## Testing
- `ruff check apps/api/app/services/memory.py tests/services/test_memory_init.py tests/services/test_memory.py`
- `mypy apps/api/app/services/memory.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a764fac82083229d5818c2785c03d6