### PR TITLE
feat: add configurable memory API timeout and retries

### DIFF
--- a/apps/api/app/core/settings.py
+++ b/apps/api/app/core/settings.py
@@ -25,9 +25,11 @@ class Settings(BaseSettings):
     agent_run_timeout_seconds: int = 30
     agent_retry_max_attempts: int = 3
     agent_retry_backoff_seconds: float = 1.0
+    memory_api_timeout: float = 5.0
+    memory_api_retries: int = 1
 
 
-@lru_cache()
+@lru_cache
 def get_settings() -> Settings:
     """Return cached application settings."""
 


### PR DESCRIPTION
## Summary
- make `_with_retry` configurable for timeout and retries
- expose `MEMORY_API_TIMEOUT` and `MEMORY_API_RETRIES` settings
- cover memory service operations with tests for custom timeout/retry behavior

## Testing
- `black apps/api/app/services/memory.py apps/api/app/core/settings.py tests/services/test_memory.py`
- `ruff check apps/api/app/services/memory.py apps/api/app/core/settings.py tests/services/test_memory.py`
- `mypy apps/api/app/services/memory.py apps/api/app/core/settings.py`
- `pytest tests/services/test_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_68a7696abad083228efa56f08ad7f24c