### PR TITLE
feat: add R2R document ingestion endpoint

### DIFF
--- a/tests/services/test_rag.py
+++ b/tests/services/test_rag.py
@@ -1,19 +1,64 @@
 import pytest
 import respx
 from httpx import Response
-from apps.api.app.services import rag as rag_service
+
 from apps.api.app.exceptions import R2RServiceError
+from apps.api.app.services import rag as rag_module
+
 
 @respx.mock
 @pytest.mark.asyncio
 async def test_rag_success() -> None:
-    respx.post(f"{rag_service.R2R_BASE}/api/retrieval/rag").mock(return_value=Response(200, json={"ok": True}))
-    result = await rag_service.rag("hello")
+    respx.post(f"{rag_module.R2R_BASE}/api/retrieval/rag").mock(
+        return_value=Response(200, json={"ok": True})
+    )
+    result = await rag_module.rag("hello")
     assert result == {"ok": True}
+
 
 @respx.mock
 @pytest.mark.asyncio
 async def test_rag_retries_and_fails() -> None:
-    respx.post(f"{rag_service.R2R_BASE}/api/retrieval/rag").mock(side_effect=[Response(500), Response(500), Response(500)])
+    respx.post(f"{rag_module.R2R_BASE}/api/retrieval/rag").mock(
+        side_effect=[Response(500), Response(500), Response(500)]
+    )
     with pytest.raises(R2RServiceError):
-        await rag_service.rag("boom")
+        await rag_module.rag("boom")
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_upload_document_success() -> None:
+    respx.post(f"{rag_module.R2R_BASE}/api/ingest").mock(
+        return_value=Response(200, json={"id": "1"})
+    )
+    respx.post(f"{rag_module.R2R_BASE}/api/index").mock(
+        return_value=Response(200, json={"ok": True})
+    )
+    result = await rag_module.rag_service.upload_document(
+        b"hello", filename="a.txt", content_type="text/plain"
+    )
+    assert result == {"ok": True}
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_upload_document_index_failure() -> None:
+    respx.post(f"{rag_module.R2R_BASE}/api/ingest").mock(
+        return_value=Response(200, json={"id": "1"})
+    )
+    respx.post(f"{rag_module.R2R_BASE}/api/index").mock(
+        side_effect=[Response(500), Response(500), Response(500)]
+    )
+    with pytest.raises(R2RServiceError):
+        await rag_module.rag_service.upload_document(
+            b"bad", filename="a.txt", content_type="text/plain"
+        )
+
+
+@pytest.mark.asyncio
+async def test_upload_document_invalid_type() -> None:
+    with pytest.raises(ValueError):
+        await rag_module.rag_service.upload_document(
+            b"data", filename="a.exe", content_type="application/octet-stream"
+        )


### PR DESCRIPTION
## Summary
- add RAG service method for uploading documents with validation, chunking, and retrying R2R ingest/index calls
- expose `/rag/documents` FastAPI route
- test document ingest success and error paths

## Testing
- `ruff check apps/api/app/services/rag.py apps/api/app/routers/rag.py tests/services/test_rag.py tests/api/test_rag_router.py`
- `mypy --follow-imports=skip apps/api/app/services/rag.py apps/api/app/routers/rag.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a772846d288322ac8b9e3495278f85