### PR TITLE
feat: add metadata filters and search modes to RAG API

### DIFF
--- a/apps/api/app/models/schemas.py
+++ b/apps/api/app/models/schemas.py
@@ -1,19 +1,37 @@
-from pydantic import BaseModel
-from typing import Optional, Literal, List
+from typing import Literal
+
+from pydantic import BaseModel, field_validator
+
 
 class MemoryItem(BaseModel):
-    id: Optional[str] = None
+    id: str | None = None
     text: str
-    scope: Literal["user","agent","session","global"] = "user"
-    user_id: Optional[str] = None
-    agent_id: Optional[str] = None
-    run_id: Optional[str] = None
+    scope: Literal["user", "agent", "session", "global"] = "user"
+    user_id: str | None = None
+    agent_id: str | None = None
+    run_id: str | None = None
     metadata: dict | None = None
+
 
 class RAGQuery(BaseModel):
     query: str
-    use_kg: bool = True
+    filters: dict[str, str] | None = None
+    vector: bool = True
+    keyword: bool = True
+    graph: bool = True
     limit: int = 25
+
+    @field_validator("filters")
+    @classmethod
+    def validate_filters(cls, value: dict[str, str] | None) -> dict[str, str] | None:
+        if value is None:
+            return None
+        if any(
+            not isinstance(k, str) or not isinstance(v, str) for k, v in value.items()
+        ):
+            raise ValueError("filters must be string key-value pairs")
+        return value
+
 
 class AgentPrompt(BaseModel):
     prompt: str

--- a/apps/api/app/routers/rag.py
+++ b/apps/api/app/routers/rag.py
@@ -15,7 +15,14 @@ async def run_rag(
     payload: RAGQuery, user: User = Depends(require_roles(["user"]))
 ) -> dict[str, Any]:
     try:
-        return await rag(payload.query, use_kg=payload.use_kg, limit=payload.limit)
+        return await rag(
+            payload.query,
+            filters=payload.filters,
+            vector=payload.vector,
+            keyword=payload.keyword,
+            graph=payload.graph,
+            limit=payload.limit,
+        )
     except R2RServiceError as exc:  # pragma: no cover - error path
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 


### PR DESCRIPTION
## Summary
- expand RAG query schema with metadata filters and search-mode flags
- pass filters and search options through RAG service and router
- test hybrid, metadata-filtered, and semantic search paths

## Testing
- `ruff check apps/api/app/services/rag.py apps/api/app/routers/rag.py apps/api/app/models/schemas.py tests/services/test_rag.py tests/api/test_rag_router.py`
- `mypy apps/api/app/services/rag.py apps/api/app/routers/rag.py apps/api/app/models/schemas.py tests/services/test_rag.py tests/api/test_rag_router.py` (fails: Missing type parameters for generic type "dict" and other existing issues)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a774c04670832295d09e39cd11bf8d