### PR TITLE
Add LangGraph workflow service and tests

### DIFF
--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -9,6 +9,10 @@ class R2RServiceError(AgentFlowError):
     """Raised when R2R service integration fails."""
 
 
+class WorkflowExecutionError(AgentFlowError):
+    """Raised when workflow execution fails."""
+
+
 class MemoryServiceError(AgentFlowError):
     """Raised when memory operations fail."""
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -6,7 +6,7 @@ from slowapi.middleware import SlowAPIMiddleware
 from .config import get_settings
 from .middleware import AuditMiddleware
 from .rate_limiter import limiter
-from .routers import agents, auth, cache_examples, health, memory, rag
+from .routers import agents, auth, cache_examples, health, memory, rag, workflow
 from .utils.logging import setup_logging
 
 
@@ -34,5 +34,6 @@ app.include_router(auth.router, prefix="/auth", tags=["auth"])
 app.include_router(memory.router, prefix="/memory", tags=["memory"])
 app.include_router(rag.router, prefix="/rag", tags=["rag"])
 app.include_router(agents.router, prefix="/agents", tags=["agents"])
+app.include_router(workflow.router, prefix="/workflow", tags=["workflow"])
 app.include_router(health.router)
 app.include_router(cache_examples.router, tags=["cache"])

--- a/apps/api/app/routers/workflow.py
+++ b/apps/api/app/routers/workflow.py
@@ -1,0 +1,47 @@
+"""Workflow API router."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from ..exceptions import WorkflowExecutionError
+from ..services.workflow import WorkflowService
+
+router = APIRouter()
+
+
+class WorkflowRequest(BaseModel):
+    """Request model for running a workflow."""
+
+    workflow_id: str = Field(..., min_length=1)
+    inputs: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowResponse(BaseModel):
+    """Response model containing workflow results."""
+
+    result: dict[str, Any]
+
+
+def get_service() -> WorkflowService:
+    """Return a workflow service instance."""
+
+    return WorkflowService()
+
+
+@router.post("/run", response_model=WorkflowResponse)
+async def run_workflow(
+    req: WorkflowRequest, service: WorkflowService = Depends(get_service)
+) -> WorkflowResponse:
+    """Execute a workflow and return its result."""
+    try:
+        result = await service.execute(req.workflow_id, req.inputs)
+    except WorkflowExecutionError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return WorkflowResponse(result=result)
+
+
+__all__ = ["router", "get_service"]

--- a/apps/api/app/services/workflow.py
+++ b/apps/api/app/services/workflow.py
@@ -1,0 +1,55 @@
+"""LangGraph workflow service.
+
+This module provides a thin wrapper around the LangGraph runner with
+timeout and retry logic. It validates basic inputs and converts runtime
+errors into :class:`WorkflowExecutionError` exceptions for upstream
+handlers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Protocol
+
+from ..exceptions import WorkflowExecutionError
+
+
+class RunnerProtocol(Protocol):
+    """Protocol describing the minimal LangGraph runner interface."""
+
+    async def run(self, workflow_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Execute a workflow and return its result."""
+
+
+def get_runner() -> RunnerProtocol:  # pragma: no cover - external dependency
+    """Return the default LangGraph runner instance."""
+    from langgraph_sdk import WorkflowRunner  # type: ignore[import-not-found]
+
+    return WorkflowRunner()
+
+
+class WorkflowService:
+    """Service for executing LangGraph workflows."""
+
+    def __init__(self, runner: RunnerProtocol | None = None) -> None:
+        self._runner = runner or get_runner()
+
+    async def execute(self, workflow_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        """Run a workflow with retries and timeout handling."""
+        if not workflow_id:
+            raise ValueError("workflow_id must not be empty")
+
+        for attempt in range(3):
+            try:
+                return await asyncio.wait_for(
+                    self._runner.run(workflow_id, inputs), timeout=5.0
+                )
+            except Exception as exc:  # pragma: no cover - exercised in tests
+                if attempt == 2:
+                    raise WorkflowExecutionError("workflow execution failed") from exc
+                await asyncio.sleep(0.1)
+
+        raise WorkflowExecutionError("workflow execution failed")
+
+
+__all__ = ["WorkflowService", "get_runner", "RunnerProtocol"]

--- a/tests/langgraph/test_workflow.py
+++ b/tests/langgraph/test_workflow.py
@@ -1,0 +1,68 @@
+import os
+import pathlib
+import sys
+import types
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+os.environ.setdefault("SECRET_KEY", "test")
+
+# Stub external LangGraph dependency
+mock_langgraph = types.ModuleType("langgraph_sdk")
+
+
+class DummyRunner:
+    async def run(self, workflow_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        return {"message": "ok"}
+
+
+class FailingRunner:
+    async def run(self, workflow_id: str, inputs: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("boom")
+
+
+mock_langgraph.WorkflowRunner = DummyRunner  # type: ignore[attr-defined]
+sys.modules["langgraph_sdk"] = mock_langgraph
+
+from apps.api.app.routers import workflow as workflow_router  # noqa: E402
+from apps.api.app.services import workflow as workflow_service  # noqa: E402
+
+
+def create_app(service: workflow_service.WorkflowService) -> FastAPI:
+    app = FastAPI()
+    app.dependency_overrides[workflow_router.get_service] = lambda: service
+    app.include_router(workflow_router.router, prefix="/workflow")
+    return app
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workflow_service, "get_runner", lambda: DummyRunner())
+    app = create_app(workflow_service.WorkflowService())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/workflow/run",
+            json={"workflow_id": "wf", "inputs": {"x": 1}},
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"result": {"message": "ok"}}
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(workflow_service, "get_runner", lambda: FailingRunner())
+    app = create_app(workflow_service.WorkflowService())
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post(
+            "/workflow/run",
+            json={"workflow_id": "wf", "inputs": {}},
+        )
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "workflow execution failed"


### PR DESCRIPTION
## Summary
- add workflow service with timeout, retry and custom exception
- expose workflow API router and integrate into main app
- test workflow success and failure paths with mocked LangGraph runner

## Testing
- `pytest tests/langgraph -v --cov=apps/api/app/services/workflow.py`
- `coverage report apps/api/app/services/workflow.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78197762c8322b04f2aadd5b1465c