### PR TITLE
test: add MCP server tests

### DIFF
--- a/apps/mcp/server.py
+++ b/apps/mcp/server.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+from typing import Any
 
 from loguru import logger
 from mcp.server.fastmcp import Context, FastMCP
@@ -10,13 +11,13 @@ mcp = FastMCP("AgentFlow MCP", debug=False, log_level="INFO")
 
 
 @mcp.tool()
-async def ping(ctx: Context) -> str:
+async def ping(ctx: Context[Any, Any, Any]) -> str:
     """Health check tool."""
     await ctx.info("pong")
     return "pong"
 
 
-def run_stdio() -> None:
+def run_stdio() -> None:  # pragma: no cover
     mcp.run()
 
 
@@ -25,7 +26,7 @@ async def run_http() -> None:
     logger.info("HTTP transport not yet implemented")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     transport = os.getenv("MCP_TRANSPORT", "stdio")
     if transport == "http":
         asyncio.run(run_http())

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -1,0 +1,49 @@
+"""Tests for MCP server tools."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp.server.fastmcp import Context
+from mcp.server.fastmcp.exceptions import ToolError
+
+from apps.mcp.server import mcp, ping, run_http
+
+
+@pytest.fixture
+def mock_context() -> AsyncMock:
+    """Provide a mocked MCP context."""
+    ctx: AsyncMock = AsyncMock(spec=Context)
+    ctx.info = AsyncMock()
+    ctx.error = AsyncMock()
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_tool_discovery() -> None:
+    """Tools should include the ping command."""
+    tools = await mcp.list_tools()
+    assert any(tool.name == "ping" for tool in tools)
+
+
+@pytest.mark.asyncio
+async def test_ping_execution(mock_context: AsyncMock) -> None:
+    """Ping tool should return pong and log info."""
+    result = await ping(mock_context)
+    assert result == "pong"
+    mock_context.info.assert_called_with("pong")
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_error() -> None:
+    """Unknown tools should raise ToolError."""
+    with pytest.raises(ToolError):
+        await mcp.call_tool("unknown", {})
+
+
+@pytest.mark.asyncio
+async def test_run_http() -> None:
+    """HTTP transport stub should execute without error."""
+    await run_http()
+    assert True


### PR DESCRIPTION
## Summary
- add async MCP server tests covering tool discovery, command execution, and error handling
- annotate MCP server context generics and exclude unused runtime paths from coverage

## Testing
- `ruff check apps/mcp tests/mcp`
- `mypy apps/mcp tests/mcp`
- `pytest tests/mcp -v --cov=apps/mcp`


------
https://chatgpt.com/codex/tasks/task_e_68a786e36cb883228f912a9d1184abb3