### PR TITLE
feat: add satisfaction score metric utility

### DIFF
--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -51,3 +51,11 @@ class OTPError(AuthenticationError):
 
 class CacheError(AgentFlowError):
     """Raised when cache operations fail."""
+
+
+class MetricsError(AgentFlowError):
+    """Raised when metrics calculations fail."""
+
+
+class InvalidRatingError(MetricsError):
+    """Raised when provided ratings are invalid."""

--- a/apps/api/app/utils/metrics.py
+++ b/apps/api/app/utils/metrics.py
@@ -1,0 +1,30 @@
+"""Utility functions for metrics calculations."""
+
+from __future__ import annotations
+
+from ..exceptions import InvalidRatingError, MetricsError
+
+
+def calculate_satisfaction_score(ratings: list[int]) -> float:
+    """Calculate a normalized satisfaction score from ratings.
+
+    Args:
+        ratings: A list of integer ratings from 1 to 5.
+
+    Returns:
+        The average rating normalized between 0 and 1.
+
+    Raises:
+        InvalidRatingError: If ratings are empty or contain invalid values.
+        MetricsError: If calculation fails unexpectedly.
+    """
+    if not isinstance(ratings, list) or not ratings:
+        raise InvalidRatingError("ratings must be a non-empty list of integers")
+
+    if any(not isinstance(r, int) or r < 1 or r > 5 for r in ratings):
+        raise InvalidRatingError("each rating must be an int between 1 and 5")
+
+    try:
+        return sum(ratings) / (len(ratings) * 5)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise MetricsError("failed to calculate satisfaction score") from exc

--- a/tests/metrics/test_satisfaction.py
+++ b/tests/metrics/test_satisfaction.py
@@ -1,0 +1,31 @@
+"""Tests for satisfaction score metric utility."""
+
+from __future__ import annotations
+
+import pytest
+
+from apps.api.app.exceptions import InvalidRatingError
+from apps.api.app.utils.metrics import calculate_satisfaction_score
+
+
+def test_calculate_satisfaction_score_success() -> None:
+    """Satisfaction score should exceed 0.9 for high ratings."""
+    ratings = [5, 5, 4, 5]
+    score = calculate_satisfaction_score(ratings)
+    assert score > 0.9
+
+
+@pytest.mark.parametrize(
+    "ratings",
+    [
+        [],
+        [0],
+        [6],
+        ["a"],
+        None,
+    ],
+)
+def test_calculate_satisfaction_score_invalid(ratings: list[int] | None) -> None:
+    """Invalid inputs should raise ``InvalidRatingError``."""
+    with pytest.raises(InvalidRatingError):
+        calculate_satisfaction_score(ratings)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add `calculate_satisfaction_score` utility with validation and custom exceptions
- cover metric utility with unit tests for success and failure cases

## Testing
- `ruff check tests/metrics/test_satisfaction.py apps/api/app/utils/metrics.py apps/api/app/exceptions.py`
- `mypy apps/api/app/utils/metrics.py apps/api/app/exceptions.py tests/metrics/test_satisfaction.py`
- `pytest tests/metrics/test_satisfaction.py --cov=apps.api.app.utils.metrics --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a794f457ac8322b23209e42e44c38f