### PR TITLE
feat: add AgentRunResponse model

### DIFF
--- a/apps/api/app/models/schemas.py
+++ b/apps/api/app/models/schemas.py
@@ -35,3 +35,7 @@ class RAGQuery(BaseModel):
 
 class AgentPrompt(BaseModel):
     prompt: str
+
+
+class AgentRunResponse(BaseModel):
+    result: str

--- a/apps/api/app/routers/agents.py
+++ b/apps/api/app/routers/agents.py
@@ -2,16 +2,16 @@ from fastapi import APIRouter, Depends, HTTPException
 
 from ..dependencies import User, require_roles
 from ..exceptions import AgentFlowError
-from ..models.schemas import AgentPrompt
+from ..models.schemas import AgentPrompt, AgentRunResponse
 from ..services.agents import run_agent
 
 router = APIRouter()
 
 
-@router.post("/run", summary="Run agent")
+@router.post("/run", summary="Run agent", response_model=AgentRunResponse)
 async def run(payload: AgentPrompt, user: User = Depends(require_roles(["user"]))):
     try:
         result = await run_agent(payload.prompt)
-        return {"result": result}
+        return AgentRunResponse(result=result)
     except AgentFlowError as exc:  # pragma: no cover - error path
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/tests/api/test_agents_router.py
+++ b/tests/api/test_agents_router.py
@@ -3,6 +3,7 @@ from httpx import ASGITransport, AsyncClient
 
 from apps.api.app.exceptions import AgentFlowError
 from apps.api.app.main import app
+from apps.api.app.models.schemas import AgentRunResponse
 from apps.api.app.routers import agents as agents_router
 
 
@@ -17,6 +18,8 @@ async def test_run_agent_success(monkeypatch) -> None:
         resp = await ac.post("/agents/run", json={"prompt": "hello"})
     assert resp.status_code == 200
     assert resp.json() == {"result": "ok"}
+    model = AgentRunResponse(**resp.json())
+    assert model.result == "ok"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- define AgentRunResponse with result field
- update agents router to return AgentRunResponse
- test agent run endpoint with response schema validation

## Testing
- `black apps/api/app/models/schemas.py apps/api/app/routers/agents.py tests/api/test_agents_router.py`
- `isort apps/api/app/models/schemas.py apps/api/app/routers/agents.py tests/api/test_agents_router.py`
- `flake8 apps/api/app/models/schemas.py apps/api/app/routers/agents.py tests/api/test_agents_router.py` *(fails: command not found)*
- `uv run mypy apps/api/app/models/schemas.py apps/api/app/routers/agents.py tests/api/test_agents_router.py` *(fails: mem0-ai not found)*
- `uv run bandit -r apps/api/app/models/schemas.py apps/api/app/routers/agents.py` *(fails: mem0-ai not found)*
- `pytest tests/api/test_agents_router.py -v --cov=apps`


------
https://chatgpt.com/codex/tasks/task_e_68a7d4173c708322aab75467b3a9d0fa