### PR TITLE
feat: add cache response models

### DIFF
--- a/apps/api/app/models/cache.py
+++ b/apps/api/app/models/cache.py
@@ -1,0 +1,19 @@
+"""Pydantic models for cache operations."""
+
+from pydantic import BaseModel
+
+
+class CacheEntry(BaseModel):
+    """Represents a cached key-value pair."""
+
+    key: str
+    value: str
+    cached: bool
+
+
+class CachePostResponse(BaseModel):
+    """Response model for cached POST requests."""
+
+    id: str
+    value: str
+    cached: bool

--- a/apps/api/app/routers/cache_examples.py
+++ b/apps/api/app/routers/cache_examples.py
@@ -1,11 +1,13 @@
 """Example routes demonstrating caching and idempotent POST."""
 
 import asyncio
+
 from fastapi import APIRouter, Depends, Header, HTTPException, status
 from pydantic import BaseModel
 
 from ..core.cache import Cache, get_cache
 from ..exceptions import CacheError
+from ..models.cache import CacheEntry, CachePostResponse
 
 router = APIRouter()
 
@@ -15,35 +17,49 @@ class Item(BaseModel):
     value: str
 
 
-@router.get("/cache/{key}")
-async def cached_get(key: str, cache: Cache = Depends(get_cache)) -> dict:
+@router.get("/cache/{key}", response_model=CacheEntry)
+async def cached_get(
+    key: str, cache: Cache = Depends(get_cache)
+) -> CacheEntry:  # noqa: E501
     """Return data using Redis caching."""
 
     try:
         cached = await cache.get(key)
         if cached is not None:
-            return {"key": key, "value": cached, "cached": True}
+            return CacheEntry(key=key, value=cached, cached=True)
         await asyncio.sleep(0.2)
         value = f"value-for-{key}"
         await cache.set(key, value)
-        return {"key": key, "value": value, "cached": False}
+        return CacheEntry(key=key, value=value, cached=False)
     except CacheError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
-@router.post("/cache/items", status_code=status.HTTP_201_CREATED)
+@router.post(
+    "/cache/items",
+    status_code=status.HTTP_201_CREATED,
+    response_model=CachePostResponse,
+)
 async def cached_post(
     item: Item,
     idempotency_key: str = Header(..., alias="Idempotency-Key"),
     cache: Cache = Depends(get_cache),
-) -> dict:
+) -> CachePostResponse:
     """Idempotent item creation using cache."""
 
     try:
         existing = await cache.get(idempotency_key)
         if existing is not None:
-            return {"id": idempotency_key, "value": existing, "cached": True}
+            return CachePostResponse(
+                id=idempotency_key,
+                value=existing,
+                cached=True,
+            )
         await cache.set(idempotency_key, item.value)
-        return {"id": idempotency_key, "value": item.value, "cached": False}
+        return CachePostResponse(
+            id=idempotency_key,
+            value=item.value,
+            cached=False,
+        )
     except CacheError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/tests/api/test_cache_examples.py
+++ b/tests/api/test_cache_examples.py
@@ -15,10 +15,15 @@ os.environ.setdefault("QDRANT_URL", "http://localhost:6333")
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("OPENAI_API_KEY", "test")
 
-from apps.api.app import config
-from apps.api.app.core.cache import Cache, get_cache
-from apps.api.app.exceptions import CacheError
-from apps.api.app.main import app
+from apps.api.app import config  # noqa: E402
+from apps.api.app.core.cache import Cache, get_cache  # noqa: E402
+from apps.api.app.exceptions import CacheError  # noqa: E402
+from apps.api.app.main import app  # noqa: E402
+from apps.api.app.models.cache import (  # noqa: E402
+    CacheEntry,
+    CachePostResponse,
+)
+from apps.api.app.middleware.audit import MiddlewareError  # noqa: E402
 
 config.get_settings.cache_clear()
 
@@ -40,7 +45,8 @@ async def test_cached_get_under_100ms() -> None:
         resp = await ac.get("/cache/foo")
         duration = (time.perf_counter() - start) * 1000
         assert resp.status_code == 200
-        assert resp.json()["cached"] is True
+        data = CacheEntry(**resp.json())
+        assert data.cached is True
         assert duration < 100
 
 
@@ -54,7 +60,8 @@ async def test_idempotent_post() -> None:
         assert first.status_code == 201
         second = await ac.post("/cache/items", json=payload, headers=headers)
         assert second.status_code == 201
-        assert second.json()["cached"] is True
+        data = CachePostResponse(**second.json())
+        assert data.cached is True
 
 
 @pytest.mark.asyncio
@@ -69,6 +76,20 @@ async def test_cached_get_error_returns_500(
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get("/cache/foo")
     assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_cached_get_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def invalid_get(self: Cache, key: str) -> dict:
+        return {"unexpected": "dict"}
+
+    monkeypatch.setattr(Cache, "get", invalid_get)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        with pytest.raises(MiddlewareError):
+            await ac.get("/cache/foo")
 
 
 @pytest.mark.asyncio
@@ -87,3 +108,19 @@ async def test_cached_post_error_returns_500(
         payload = {"key": "k1", "value": "v1"}
         resp = await ac.post("/cache/items", json=payload, headers=headers)
     assert resp.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_cached_post_validation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def invalid_get(self: Cache, key: str) -> dict:
+        return {"unexpected": "dict"}
+
+    monkeypatch.setattr(Cache, "get", invalid_get)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        headers = {"Idempotency-Key": "abc"}
+        payload = {"key": "k1", "value": "v1"}
+        with pytest.raises(MiddlewareError):
+            await ac.post("/cache/items", json=payload, headers=headers)


### PR DESCRIPTION
## Summary
- add CacheEntry and CachePostResponse models for cache endpoints
- enforce response models in cache example router
- test cache endpoints for schema validation

## Testing
- `flake8 apps/ tests/` *(fails: line length and import issues across project)*
- `flake8 apps/api/app/routers/cache_examples.py apps/api/app/models/cache.py tests/api/test_cache_examples.py`
- `mypy apps/` *(fails: missing modules and type annotations)*
- `bandit -r apps/`
- `pytest tests/ -v --cov=apps` *(fails: import file mismatch in tests/services/test_agents.py)*
- `pytest tests/api/test_cache_examples.py -v --cov=apps/api/app/routers/cache_examples.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7dbd8e5e483228ed989748f9c4c77