### PR TITLE
feat: add HealthStatus response model

### DIFF
--- a/apps/api/app/models/health.py
+++ b/apps/api/app/models/health.py
@@ -1,0 +1,11 @@
+"""Pydantic models for health checks."""
+
+from typing import Literal
+
+from pydantic import BaseModel
+
+
+class HealthStatus(BaseModel):
+    """Represents the health status of the service."""
+
+    status: Literal["ok", "ready"]


### PR DESCRIPTION
## Summary
- add HealthStatus Pydantic model for health endpoints
- use HealthStatus as response model for `/health` and `/readiness`
- test health endpoints using HealthStatus validation

## Testing
- `black apps/api/app/models/health.py apps/api/app/routers/health.py tests/api/test_health.py`
- `isort apps/api/app/models/health.py apps/api/app/routers/health.py tests/api/test_health.py`
- `flake8 apps/api/app/models/health.py apps/api/app/routers/health.py tests/api/test_health.py`
- `mypy --follow-imports=skip apps/api/app/models/health.py apps/api/app/routers/health.py`
- `bandit -r apps/api/app/routers/health.py apps/api/app/models/health.py`
- `pytest tests/api/test_health.py -v --cov=apps`

------
https://chatgpt.com/codex/tasks/task_e_68a7ec3701ec832289f180a30c362de2