### PR TITLE
feat: add response models for rag

### DIFF
--- a/apps/api/app/models/rag.py
+++ b/apps/api/app/models/rag.py
@@ -1,0 +1,19 @@
+"""Response models for RAG operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class RAGSearchResponse(BaseModel):
+    """Schema for responses returned by RAG search."""
+
+    results: list[Any]
+
+
+class DocumentUploadResponse(BaseModel):
+    """Schema for responses after uploading a document."""
+
+    ok: bool

--- a/apps/api/app/routers/rag.py
+++ b/apps/api/app/routers/rag.py
@@ -1,21 +1,20 @@
-from typing import Any
-
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 
 from ..dependencies import User, require_roles
 from ..exceptions import R2RServiceError
+from ..models.rag import DocumentUploadResponse, RAGSearchResponse
 from ..models.schemas import RAGQuery
 from ..services.rag import rag, rag_service
 
 router = APIRouter()
 
 
-@router.post("/", summary="Run RAG search")
+@router.post("/", summary="Run RAG search", response_model=RAGSearchResponse)
 async def run_rag(
     payload: RAGQuery, user: User = Depends(require_roles(["user"]))
-) -> dict[str, Any]:
+) -> RAGSearchResponse:
     try:
-        return await rag(
+        result = await rag(
             payload.query,
             filters=payload.filters,
             vector=payload.vector,
@@ -23,22 +22,28 @@ async def run_rag(
             graph=payload.graph,
             limit=payload.limit,
         )
+        return RAGSearchResponse.model_validate(result)
     except R2RServiceError as exc:  # pragma: no cover - error path
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
 
-@router.post("/documents", summary="Upload document to R2R")
+@router.post(
+    "/documents",
+    summary="Upload document to R2R",
+    response_model=DocumentUploadResponse,
+)
 async def upload_document(
     file: UploadFile = File(...),
     user: User = Depends(require_roles(["user"])),
-) -> dict[str, Any]:
+) -> DocumentUploadResponse:
     content = await file.read()
     filename = file.filename or "upload"
     content_type = file.content_type or "application/octet-stream"
     try:
-        return await rag_service.upload_document(
+        result = await rag_service.upload_document(
             content, filename=filename, content_type=content_type
         )
+        return DocumentUploadResponse.model_validate(result)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except R2RServiceError as exc:  # pragma: no cover - error path


### PR DESCRIPTION
## Summary
- add RAGSearchResponse and DocumentUploadResponse schemas
- return typed responses from RAG routes
- validate response schemas in RAG router tests

## Testing
- `isort --check-only -v apps/api/app/routers/rag.py apps/api/app/models/rag.py tests/api/test_rag_router.py`
- `black tests/api/test_rag_router.py apps/api/app/routers/rag.py apps/api/app/models/rag.py`
- `flake8 apps/api/app/routers/rag.py apps/api/app/models/rag.py tests/api/test_rag_router.py`
- `flake8 apps/ tests/` (fails: E501 line too long and other errors)
- `mypy apps/` (fails: import-not-found and type errors)
- `bandit -r apps/`
- `pytest tests/ -v --cov=apps` (fails: import file mismatch)
- `pytest tests/api/test_rag_router.py -v --cov=apps/api/app/routers/rag.py --cov=apps/api/app/models/rag.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7ee67193c8322863a94b5a50b67c0