### PR TITLE
feat: introduce error taxonomy and tests

### DIFF
--- a/apps/api/app/errors.py
+++ b/apps/api/app/errors.py
@@ -1,0 +1,52 @@
+from enum import Enum
+
+
+class ErrorCode(str, Enum):
+    """Enumeration of application error codes."""
+
+    DOMAIN_ERROR = "D000"
+    PROVIDER_ERROR = "P000"
+    R2R_SERVICE_ERROR = "P001"
+    WORKFLOW_EXECUTION_ERROR = "D001"
+    MEMORY_SERVICE_ERROR = "D002"
+    HEALTH_CHECK_ERROR = "D003"
+    RBAC_ERROR = "D004"
+    SEED_ERROR = "D005"
+    AUTHENTICATION_ERROR = "D100"
+    INVALID_CREDENTIALS = "D101"
+    TOKEN_ERROR = "D102"
+    OTP_ERROR = "D103"
+    CACHE_ERROR = "D200"
+    METRICS_ERROR = "D300"
+    INVALID_RATING = "D301"
+
+
+class AgentFlowError(Exception):
+    """Base sealed error for AgentFlow."""
+
+    def __init__(self, message: str, code: ErrorCode) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+class DomainError(AgentFlowError):
+    """Base error for domain logic issues."""
+
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.DOMAIN_ERROR,
+    ) -> None:
+        super().__init__(message, code)
+
+
+class ProviderError(AgentFlowError):
+    """Base error for external provider failures."""
+
+    def __init__(
+        self,
+        message: str,
+        code: ErrorCode = ErrorCode.PROVIDER_ERROR,
+    ) -> None:
+        super().__init__(message, code)

--- a/apps/api/app/exceptions.py
+++ b/apps/api/app/exceptions.py
@@ -1,61 +1,125 @@
 """Custom exceptions for AgentFlow API."""
 
+from __future__ import annotations
 
-class AgentFlowError(Exception):
-    """Base class for domain exceptions."""
+from .errors import AgentFlowError, DomainError, ErrorCode, ProviderError
+
+__all__ = [
+    "AgentFlowError",
+    "R2RServiceError",
+    "WorkflowExecutionError",
+    "MemoryServiceError",
+    "HealthCheckError",
+    "RBACError",
+    "SeedError",
+    "AuthenticationError",
+    "InvalidCredentialsError",
+    "TokenError",
+    "OTPError",
+    "CacheError",
+    "MetricsError",
+    "InvalidRatingError",
+]
+# noqa: F401
 
 
-class R2RServiceError(AgentFlowError):
+class R2RServiceError(ProviderError):
     """Raised when R2R service integration fails."""
 
+    def __init__(
+        self,
+        message: str = "R2R service integration failed",
+    ) -> None:
+        super().__init__(message, ErrorCode.R2R_SERVICE_ERROR)
 
-class WorkflowExecutionError(AgentFlowError):
+
+class WorkflowExecutionError(DomainError):
     """Raised when workflow execution fails."""
 
+    def __init__(self, message: str = "Workflow execution failed") -> None:
+        super().__init__(message, ErrorCode.WORKFLOW_EXECUTION_ERROR)
 
-class MemoryServiceError(AgentFlowError):
+
+class MemoryServiceError(DomainError):
     """Raised when memory operations fail."""
 
+    def __init__(self, message: str = "Memory operation failed") -> None:
+        super().__init__(message, ErrorCode.MEMORY_SERVICE_ERROR)
 
-class HealthCheckError(AgentFlowError):
+
+class HealthCheckError(DomainError):
     """Raised when service health checks fail."""
 
-    def __init__(self, service: str, message: str):
-        super().__init__(message)
+    def __init__(
+        self, service: str, message: str = "Service health check failed"
+    ) -> None:
+        super().__init__(message, ErrorCode.HEALTH_CHECK_ERROR)
         self.service = service
 
 
-class RBACError(AgentFlowError):
+class RBACError(DomainError):
     """Raised when permission checks fail or cannot be completed."""
 
+    def __init__(self, message: str = "Permission check failed") -> None:
+        super().__init__(message, ErrorCode.RBAC_ERROR)
 
-class SeedError(AgentFlowError):
+
+class SeedError(DomainError):
     """Raised when database seeding operations fail."""
 
+    def __init__(self, message: str = "Database seeding failed") -> None:
+        super().__init__(message, ErrorCode.SEED_ERROR)
 
-class AuthenticationError(AgentFlowError):
+
+class AuthenticationError(DomainError):
     """Raised when authentication fails."""
+
+    def __init__(
+        self,
+        message: str = "Authentication failed",
+        code: ErrorCode = ErrorCode.AUTHENTICATION_ERROR,
+    ) -> None:
+        super().__init__(message, code)
 
 
 class InvalidCredentialsError(AuthenticationError):
     """Raised when user credentials are invalid."""
 
+    def __init__(self, message: str = "Invalid credentials") -> None:
+        super().__init__(message, ErrorCode.INVALID_CREDENTIALS)
+
 
 class TokenError(AuthenticationError):
     """Raised when token generation or validation fails."""
+
+    def __init__(self, message: str = "Token error") -> None:
+        super().__init__(message, ErrorCode.TOKEN_ERROR)
 
 
 class OTPError(AuthenticationError):
     """Raised when one-time password validation fails."""
 
+    def __init__(self, message: str = "OTP validation failed") -> None:
+        super().__init__(message, ErrorCode.OTP_ERROR)
 
-class CacheError(AgentFlowError):
+
+class CacheError(DomainError):
     """Raised when cache operations fail."""
 
+    def __init__(self, message: str = "Cache operation failed") -> None:
+        super().__init__(message, ErrorCode.CACHE_ERROR)
 
-class MetricsError(AgentFlowError):
+
+class MetricsError(DomainError):
     """Raised when metrics calculations fail."""
+
+    def __init__(self, message: str = "Metrics calculation failed") -> None:
+        super().__init__(message, ErrorCode.METRICS_ERROR)
 
 
 class InvalidRatingError(MetricsError):
     """Raised when provided ratings are invalid."""
+
+    def __init__(self, message: str = "Invalid rating") -> None:
+        super().__init__(message)
+        self.code = ErrorCode.INVALID_RATING

--- a/tests/api/test_errors.py
+++ b/tests/api/test_errors.py
@@ -1,0 +1,24 @@
+"""Tests for error taxonomy and codes."""
+
+from apps.api.app.errors import DomainError, ErrorCode, ProviderError
+from apps.api.app.exceptions import (HealthCheckError, InvalidCredentialsError,
+                                     R2RServiceError)
+
+
+def test_r2r_service_error_taxonomy() -> None:
+    err = R2RServiceError()
+    assert isinstance(err, ProviderError)
+    assert err.code is ErrorCode.R2R_SERVICE_ERROR
+
+
+def test_invalid_credentials_error_taxonomy() -> None:
+    err = InvalidCredentialsError()
+    assert isinstance(err, DomainError)
+    assert err.code is ErrorCode.INVALID_CREDENTIALS
+
+
+def test_health_check_error_code_and_attr() -> None:
+    err = HealthCheckError(service="redis")
+    assert isinstance(err, DomainError)
+    assert err.service == "redis"
+    assert err.code is ErrorCode.HEALTH_CHECK_ERROR


### PR DESCRIPTION
## Summary
- add centralized error taxonomy with codes
- refactor API exceptions to use new taxonomy
- test error codes and inheritance

## Testing
- `flake8 apps/api/app/errors.py apps/api/app/exceptions.py tests/api/test_errors.py`
- `mypy apps/api/app/errors.py apps/api/app/exceptions.py tests/api/test_errors.py`
- `bandit -r apps/api/app/errors.py apps/api/app/exceptions.py`
- `pytest tests/api/test_errors.py -v`
- `pytest tests/ -v --cov=apps` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f30d982c8322b9c74e19176bca87