### PR TITLE
feat: add RFC7807 error handling middleware

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -8,9 +8,11 @@ from .deps.http import shutdown_http_client, startup_http_client
 from .middleware.audit import AuditMiddleware
 from .middleware.body_size import BodySizeLimitMiddleware
 from .middleware.correlation import CorrelationIdMiddleware
+from .middleware.errors import register_error_handlers
 from .observability.tracing import setup_tracing
 from .rate_limiter import limiter
-from .routers import agents, auth, cache_examples, health, memory, rag, workflow
+from .routers import (agents, auth, cache_examples, health, memory, rag,
+                      workflow)
 from .utils.logging import setup_logging
 
 
@@ -30,6 +32,7 @@ settings = validate_settings()
 setup_logging(settings.log_level)
 setup_tracing(settings.app_name)
 app = FastAPI(title=settings.app_name, openapi_url=settings.openapi_url)
+register_error_handlers(app)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_handler)
 app.add_middleware(SlowAPIMiddleware)

--- a/apps/api/app/middleware/errors.py
+++ b/apps/api/app/middleware/errors.py
@@ -1,0 +1,64 @@
+"""Error handling middleware producing RFC 7807 responses."""
+
+from __future__ import annotations
+
+from typing import Dict, Type
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from starlette import status
+
+from ..errors import AgentFlowError, DomainError, ProviderError
+from ..exceptions import (AuthenticationError, InvalidCredentialsError,
+                          OTPError, RBACError, TokenError)
+
+EXCEPTION_STATUS: Dict[Type[AgentFlowError], int] = {
+    AuthenticationError: status.HTTP_401_UNAUTHORIZED,
+    InvalidCredentialsError: status.HTTP_401_UNAUTHORIZED,
+    TokenError: status.HTTP_401_UNAUTHORIZED,
+    OTPError: status.HTTP_400_BAD_REQUEST,
+    RBACError: status.HTTP_403_FORBIDDEN,
+    DomainError: status.HTTP_400_BAD_REQUEST,
+    ProviderError: status.HTTP_502_BAD_GATEWAY,
+    AgentFlowError: status.HTTP_500_INTERNAL_SERVER_ERROR,
+}
+
+
+def _problem_response(
+    request: Request, exc: AgentFlowError, status_code: int
+) -> JSONResponse:
+    """Build RFC 7807 problem detail response."""
+    code = exc.code.value
+    content = {
+        "type": f"/errors/{code}",
+        "title": exc.__class__.__name__,
+        "status": status_code,
+        "detail": exc.message,
+        "instance": str(request.url),
+        "code": code,
+    }
+    return JSONResponse(status_code=status_code, content=content)
+
+
+def register_error_handlers(app: FastAPI) -> None:
+    """Register exception handlers on the FastAPI app."""
+    for exc_type, status_code in EXCEPTION_STATUS.items():
+
+        async def handler(
+            request: Request, exc: AgentFlowError, *, status_code: int = status_code
+        ) -> JSONResponse:
+            try:
+                return _problem_response(request, exc, status_code)
+            except Exception:  # pragma: no cover - safety
+                return JSONResponse(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    content={
+                        "type": "/errors/internal",
+                        "title": "InternalServerError",
+                        "status": status.HTTP_500_INTERNAL_SERVER_ERROR,
+                        "detail": "Internal Server Error",
+                        "instance": str(request.url),
+                    },
+                )
+
+        app.add_exception_handler(exc_type, handler)

--- a/tests/api/test_middleware.py
+++ b/tests/api/test_middleware.py
@@ -3,8 +3,10 @@ import uuid
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from apps.api.app.exceptions import MemoryServiceError
 from apps.api.app.middleware.body_size import BodySizeLimitMiddleware
 from apps.api.app.middleware.correlation import CorrelationIdMiddleware
+from apps.api.app.middleware.errors import register_error_handlers
 
 
 def _create_app() -> FastAPI:
@@ -15,6 +17,21 @@ def _create_app() -> FastAPI:
     @app.post("/")
     async def echo(data: dict) -> dict:  # pragma: no cover - trivial
         return data
+
+    return app
+
+
+def _create_error_app() -> FastAPI:
+    app = FastAPI()
+    register_error_handlers(app)
+
+    @app.get("/")
+    async def ok() -> dict[str, str]:  # pragma: no cover - trivial
+        return {"status": "ok"}
+
+    @app.get("/boom")
+    async def boom() -> None:  # pragma: no cover - explicit
+        raise MemoryServiceError("fail")
 
     return app
 
@@ -32,3 +49,23 @@ def test_body_size_limit_triggered() -> None:
     client = TestClient(app)
     resp = client.post("/", data="x" * 20, headers={"Content-Type": "application/json"})
     assert resp.status_code == 413
+
+
+def test_error_handler_success() -> None:
+    app = _create_error_app()
+    client = TestClient(app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_error_handler_problem_detail() -> None:
+    app = _create_error_app()
+    client = TestClient(app)
+    resp = client.get("/boom")
+    body = resp.json()
+    assert resp.status_code == 400
+    assert body["title"] == "MemoryServiceError"
+    assert body["status"] == 400
+    assert body["code"] == "D002"
+    assert body["type"].endswith("D002")


### PR DESCRIPTION
## Summary
- add centralized RFC 7807 error handler for domain exceptions
- wire error middleware into FastAPI app startup
- cover error middleware success and failure paths with tests

## Testing
- `flake8 --max-line-length=100 apps/api/app/main.py apps/api/app/middleware/errors.py tests/api/test_middleware.py`
- `mypy --ignore-missing-imports --follow-imports=skip apps/api/app/middleware/errors.py`
- `bandit -r apps/`
- `pytest tests/api/test_middleware.py -v --cov=apps`


------
https://chatgpt.com/codex/tasks/task_e_68a8487a07b8832282146c9c7ce7d5f0