### PR TITLE
feat: propagate request ID through logs and tracing

### DIFF
--- a/apps/api/app/observability/tracing.py
+++ b/apps/api/app/observability/tracing.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Optional
+
 from loguru import logger
 
+from ..utils.logging import request_id_ctx_var
 
-def setup_tracing(service_name: str) -> None:
+if TYPE_CHECKING:
+    from opentelemetry.sdk.trace.export import SpanExporter
+
+
+def setup_tracing(
+    service_name: str,
+    exporter: Optional["SpanExporter"] = None,
+) -> None:
     """Configure OpenTelemetry if available."""
     try:
         from opentelemetry import trace
@@ -12,12 +22,35 @@ def setup_tracing(service_name: str) -> None:
         )
         from opentelemetry.sdk.resources import Resource
         from opentelemetry.sdk.trace import TracerProvider
-        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+        from opentelemetry.sdk.trace.export import (
+            BatchSpanProcessor,
+            SimpleSpanProcessor,
+        )
 
         resource = Resource.create({"service.name": service_name})
         provider = TracerProvider(resource=resource)
-        processor = BatchSpanProcessor(OTLPSpanExporter())
+        span_exporter = exporter or OTLPSpanExporter()
+        processor = (
+            BatchSpanProcessor(span_exporter)
+            if exporter is None
+            else SimpleSpanProcessor(span_exporter)
+        )
         provider.add_span_processor(processor)
         trace.set_tracer_provider(provider)
     except Exception as exc:  # pragma: no cover - best effort
         logger.debug("tracing_setup_skipped", error=str(exc))
+
+
+def add_request_id_to_current_span() -> None:
+    """Attach the request ID context variable to the active span."""
+    try:
+        from opentelemetry import trace
+
+        request_id = request_id_ctx_var.get()
+        if not request_id:
+            return
+        span = trace.get_current_span()
+        if span and span.is_recording():
+            span.set_attribute("request_id", request_id)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug("span_attribute_skipped", error=str(exc))

--- a/apps/api/app/utils/logging.py
+++ b/apps/api/app/utils/logging.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import sys
+from contextvars import ContextVar
+from typing import cast
 
 from loguru import logger
+from loguru._logger import Logger
+
+request_id_ctx_var: ContextVar[str | None] = ContextVar(
+    "request_id",
+    default=None,
+)
 
 
 def setup_logging(level: str = "INFO") -> None:
@@ -13,3 +21,10 @@ def setup_logging(level: str = "INFO") -> None:
     """
     logger.remove()
     logger.add(sys.stdout, serialize=True, level=level)
+
+
+def logger_with_request_id() -> Logger:
+    """Return a logger bound with the current request ID if available."""
+    request_id = request_id_ctx_var.get()
+    bound = logger.bind(request_id=request_id) if request_id else logger
+    return cast(Logger, bound)


### PR DESCRIPTION
## Summary
- add logger helper binding request_id via contextvar
- propagate request ID through middleware and tracing spans
- test request ID appears in logs and spans

## Testing
- `flake8 apps/api/app/utils/logging.py apps/api/app/middleware/correlation.py apps/api/app/observability/tracing.py tests/api/test_middleware.py`
- `mypy apps/api/app/utils/logging.py apps/api/app/middleware/correlation.py apps/api/app/observability/tracing.py`
- `bandit -r apps/api/app/utils/logging.py apps/api/app/middleware/correlation.py apps/api/app/observability/tracing.py`
- `pytest tests/api/test_middleware.py::test_request_id_propagates_to_logs_and_spans -v --cov=apps`


------
https://chatgpt.com/codex/tasks/task_e_68a84a78089c832282f562b7757de585