### PR TITLE
feat: centralize audit logging

### DIFF
--- a/apps/api/app/middleware/audit.py
+++ b/apps/api/app/middleware/audit.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-import json
-import time
 from collections.abc import Awaitable, Callable
-from contextlib import suppress
+from datetime import datetime
 
-from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import Response
+
+from ..observability.audit import AuditEvent, log_audit
 
 
 class MiddlewareError(Exception):
@@ -16,41 +15,35 @@ class MiddlewareError(Exception):
 
 
 class AuditMiddleware(BaseHTTPMiddleware):
-    """Log basic request audit information."""
+    """Record structured audit logs for each request."""
 
     async def dispatch(
         self,
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        correlation_id = getattr(request.state, "correlation_id", "")
-        try:
-            body = await request.body()
-        except Exception as exc:  # pragma: no cover - best effort
-            raise MiddlewareError("Failed to read body") from exc
-        request._body = body
-        start = time.time()
         try:
             response = await call_next(request)
         except Exception as exc:  # pragma: no cover - passthrough
-            logger.error(
-                "middleware_error", correlation_id=correlation_id, error=str(exc)
+            event = AuditEvent(
+                ts=datetime.utcnow(),
+                request_id=getattr(request.state, "correlation_id", ""),
+                actor=getattr(request.state, "actor", None),
+                route=request.url.path,
+                tools_called=getattr(request.state, "tools_called", []),
+                egress=getattr(request.state, "egress", []),
+                error=str(exc),
             )
-            raise MiddlewareError("Request processing failed") from exc
-        duration = (time.time() - start) * 1000
-        event = "auth" if request.url.path.startswith("/auth") else "request"
-        email = None
-        if event == "auth":
-            with suppress(Exception):  # pragma: no cover - best effort
-                email = json.loads(body.decode()).get("email")
-        logger.info(
-            "audit",
-            event=event,
-            method=request.method,
-            path=request.url.path,
-            status=response.status_code,
-            email=email,
-            duration_ms=round(duration, 2),
-            correlation_id=correlation_id,
+            log_audit(event)
+            raise MiddlewareError("Request processing failed.") from exc
+        event = AuditEvent(
+            ts=datetime.utcnow(),
+            request_id=getattr(request.state, "correlation_id", ""),
+            actor=getattr(request.state, "actor", None),
+            route=request.url.path,
+            tools_called=getattr(request.state, "tools_called", []),
+            egress=getattr(request.state, "egress", []),
+            error=None,
         )
+        log_audit(event)
         return response

--- a/apps/api/app/observability/audit.py
+++ b/apps/api/app/observability/audit.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from loguru import logger
+from pydantic import BaseModel
+
+
+class AuditLogError(Exception):
+    """Raised when audit logging fails."""
+
+
+class AuditEvent(BaseModel):
+    ts: datetime
+    request_id: Optional[str] = None
+    actor: Optional[str] = None
+    route: str
+    tools_called: List[str] = []
+    egress: List[str] = []
+    error: Optional[str] = None
+
+
+def log_audit(event: AuditEvent) -> None:
+    """Emit a structured audit log entry."""
+    try:
+        payload = event.model_dump(mode="json", exclude_none=True)
+        logger.info("audit", **payload)
+    except Exception as exc:  # pragma: no cover - best effort
+        raise AuditLogError("Audit logging failed.") from exc


### PR DESCRIPTION
## Summary
- add `log_audit` utility for structured audit events
- capture actor, tools, egress and errors in `AuditMiddleware`
- test audit middleware logging behaviour

## Testing
- `flake8 apps/api/app/middleware/audit.py apps/api/app/observability/audit.py tests/api/test_middleware.py`
- `mypy apps/api/app/middleware/audit.py apps/api/app/observability/audit.py`
- `bandit apps/api/app/middleware/audit.py apps/api/app/observability/audit.py`
- `pytest tests/api/test_middleware.py::test_audit_middleware_logs_event tests/api/test_middleware.py::test_audit_middleware_logs_error -v --import-mode=importlib`
- `pytest tests/ -v --cov=apps --import-mode=importlib` *(fails: AgentFlowError missing code, other unrelated tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a85386ccb083228201526aaf892377