### PR TITLE
refactor: expose token store helpers

### DIFF
--- a/apps/api/app/core/settings.py
+++ b/apps/api/app/core/settings.py
@@ -38,4 +38,4 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return cached application settings."""
 
-    return Settings()
+    return Settings()  # type: ignore[call-arg]

--- a/apps/api/app/services/auth.py
+++ b/apps/api/app/services/auth.py
@@ -12,12 +12,12 @@ import pyotp
 
 from .. import config
 from ..exceptions import InvalidCredentialsError, OTPError, TokenError
-from .token_store import (
-    is_refresh_token_blacklisted,
-    revoke_refresh_token,
-    store_refresh_token,
-    verify_refresh_token,
-)
+from . import token_store
+
+is_refresh_token_blacklisted = token_store.is_refresh_token_blacklisted
+revoke_refresh_token = token_store.revoke_refresh_token
+store_refresh_token = token_store.store_refresh_token
+verify_refresh_token = token_store.verify_refresh_token
 
 settings = config.get_settings()
 USERS: Dict[str, str] = {}


### PR DESCRIPTION
## Summary
- import token store module in auth service and re-export helper functions
- silence mypy call-arg warning when instantiating Settings

## Testing
- `flake8 --max-line-length 100 apps/api/app/core/settings.py apps/api/app/services/auth.py`
- `mypy apps/api/app/services/auth.py`
- `bandit -r apps/api/app/services/auth.py`
- `bandit -r apps/api/app/core/settings.py`
- `pytest tests/api/test_auth.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a85696cb688322a14adeacd2e09f79