### PR TITLE
test: add API middleware and database tests

### DIFF
--- a/tests/api/test_audit_log_minimal.py
+++ b/tests/api/test_audit_log_minimal.py
@@ -1,0 +1,35 @@
+import json
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from loguru import logger
+
+from apps.api.app.middleware.audit import AuditMiddleware
+from apps.api.app.middleware.correlation import CorrelationIdMiddleware
+
+
+def test_audit_log_minimal() -> None:
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+    app.add_middleware(AuditMiddleware)
+
+    @app.get("/")
+    async def index() -> dict[str, str]:
+        return {"status": "ok"}
+
+    captured: list[str] = []
+    logger.remove()
+    logger.add(lambda m: captured.append(m), serialize=True)
+
+    client = TestClient(app, raise_server_exceptions=False)
+    request_id = str(uuid.uuid4())
+    response = client.get("/", headers={"X-Request-ID": request_id})
+    assert response.status_code == 200
+
+    record = json.loads(captured[0])["record"]["extra"]
+    assert record["request_id"] == request_id
+    assert record["route"] == "/"
+    assert record.get("actor") is None
+    assert record["tools_called"] == []
+    assert record["egress"] == []

--- a/tests/api/test_correlation_header_roundtrip.py
+++ b/tests/api/test_correlation_header_roundtrip.py
@@ -1,0 +1,21 @@
+import uuid
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apps.api.app.middleware.correlation import CorrelationIdMiddleware
+
+
+def test_correlation_header_roundtrip() -> None:
+    app = FastAPI()
+    app.add_middleware(CorrelationIdMiddleware)
+
+    @app.get("/")
+    async def index() -> dict[str, str]:
+        return {"status": "ok"}
+
+    client = TestClient(app, raise_server_exceptions=False)
+    request_id = str(uuid.uuid4())
+    response = client.get("/", headers={"X-Request-ID": request_id})
+    assert response.status_code == 200
+    assert response.headers["X-Request-ID"] == request_id

--- a/tests/api/test_db_tx_boundaries.py
+++ b/tests/api/test_db_tx_boundaries.py
@@ -1,0 +1,23 @@
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from apps.api.app.db.models import Organization
+
+
+class ServiceError(Exception):
+    """Raised when the service fails."""
+
+
+async def failing_service(session: AsyncSession) -> None:
+    async with session.begin():
+        session.add(Organization(name="Org"))
+        raise ServiceError("boom")
+
+
+@pytest.mark.asyncio
+async def test_db_tx_boundaries(session: AsyncSession) -> None:
+    with pytest.raises(ServiceError):
+        await failing_service(session)
+    count = await session.scalar(select(func.count()).select_from(Organization))
+    assert count == 0

--- a/tests/api/test_http_client_retries.py
+++ b/tests/api/test_http_client_retries.py
@@ -1,0 +1,32 @@
+import httpx
+import pytest
+import respx
+
+from apps.api.app import config
+from apps.api.app.deps import http
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_http_client_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_KEY", "x")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+    monkeypatch.setenv("HTTP_MAX_RETRIES", "3")
+    config.get_settings.cache_clear()
+    await http.startup_http_client()
+
+    req = httpx.Request("GET", "https://api.example.com/")
+    responses: list[httpx.Response | Exception] = [
+        httpx.HTTPStatusError("rate", request=req, response=httpx.Response(429)),
+        httpx.HTTPStatusError("server", request=req, response=httpx.Response(500)),
+        httpx.Response(200),
+    ]
+    route = respx.get("https://api.example.com/").mock(side_effect=responses)
+
+    response = await http.request("GET", "https://api.example.com/")
+    assert response.status_code == 200
+    assert route.call_count == 3
+
+    await http.shutdown_http_client()

--- a/tests/api/test_router_response_models.py
+++ b/tests/api/test_router_response_models.py
@@ -1,0 +1,15 @@
+from fastapi.routing import APIRoute
+
+from apps.api.app.main import app
+
+
+def test_router_response_models() -> None:
+    routes = [route for route in app.routes if isinstance(route, APIRoute)]
+    missing = [
+        route.path
+        for route in routes
+        if route.response_model is None
+        and "DELETE" not in route.methods
+        and route.path != "/memory/stream"
+    ]
+    assert missing == []


### PR DESCRIPTION
## Summary
- add correlation ID middleware roundtrip test
- verify HTTP client retries on 429/5xx responses
- ensure FastAPI routes include response models
- check database transaction rollback on failure
- validate audit middleware logging

## Testing
- `python -m isort tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py`
- `python -m black tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py`
- `python -m flake8 tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py` *(fails: No module named flake8)*
- `python -m mypy tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py` *(fails: Missing imports / interrupted)*
- `bandit -r tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py` *(fails: command not found)*
- `pytest tests/api/test_correlation_header_roundtrip.py tests/api/test_http_client_retries.py tests/api/test_router_response_models.py tests/api/test_db_tx_boundaries.py tests/api/test_audit_log_minimal.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a858b983b48322913cd281ca42efbe