### PR TITLE
feat: add MCP tool utilities

### DIFF
--- a/apps/mcp/tools/middleware.py
+++ b/apps/mcp/tools/middleware.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from asyncio import Lock, TimeoutError
+from collections import deque
+from functools import wraps
+from typing import Any, Awaitable, Callable, Deque, Dict
+
+logger = logging.getLogger(__name__)
+SECRET_PATTERN = re.compile(r"[A-Za-z0-9]{32,}")
+
+
+class RateLimitError(Exception):
+    """Raised when rate limits are exceeded."""
+
+
+class ToolExecutionError(Exception):
+    """Raised when tool execution fails."""
+
+
+class RateLimiter:
+    """Simple sliding-window rate limiter."""
+
+    def __init__(self, per_tool_limit: int = 60, global_limit: int = 60) -> None:
+        self.per_tool_limit = per_tool_limit
+        self.global_limit = global_limit
+        self.tool_calls: Dict[str, Deque[float]] = {}
+        self.global_calls: Deque[float] = deque()
+        self.lock = Lock()
+
+    async def check(self, name: str) -> None:
+        async with self.lock:
+            now = time.monotonic()
+            cutoff = now - 60
+            calls = self.tool_calls.setdefault(name, deque())
+            while calls and calls[0] < cutoff:
+                calls.popleft()
+            while self.global_calls and self.global_calls[0] < cutoff:
+                self.global_calls.popleft()
+            if (
+                len(calls) >= self.per_tool_limit
+                or len(self.global_calls) >= self.global_limit
+            ):
+                raise RateLimitError(f"Rate limit exceeded for {name}")
+            calls.append(now)
+            self.global_calls.append(now)
+
+
+def scrub_log(text: str) -> str:
+    """Mask secrets in log messages."""
+    return SECRET_PATTERN.sub("***", text)
+
+
+def with_middleware(
+    name: str, timeout_s: float, limiter: RateLimiter | None = None
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator adding timeout, rate limiting, and logging."""
+    limiter = limiter or RateLimiter()
+
+    def decorator(func: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        @wraps(func)
+        async def wrapper(ctx: Any, *args: Any, **kwargs: Any) -> Any:
+            await limiter.check(name)
+            logger.info(scrub_log(f"start {name}"))
+            try:
+                result = await asyncio.wait_for(
+                    func(ctx, *args, **kwargs), timeout=timeout_s
+                )
+                logger.info(scrub_log(f"end {name}"))
+                return result
+            except RateLimitError:
+                logger.error(scrub_log(f"rate limit {name}"))
+                raise
+            except TimeoutError as exc:
+                logger.error(scrub_log(f"timeout {name}"))
+                raise ToolExecutionError("timeout") from exc
+            except Exception as exc:
+                logger.exception(scrub_log(f"error {name}: {exc}"))
+                raise ToolExecutionError(str(exc)) from exc
+
+        return wrapper
+
+    return decorator

--- a/apps/mcp/tools/registry.py
+++ b/apps/mcp/tools/registry.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict, Optional, Set
+
+
+class ToolRegistry:
+    """Registry for MCP tools with allowlist enforcement."""
+
+    def __init__(self, allowlist: Optional[Set[str]] = None) -> None:
+        self.allowlist = allowlist
+        self._tools: Dict[str, Callable[..., Awaitable[Any]]] = {}
+
+    def register(
+        self, name: str
+    ) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+        """Decorator to register a tool function."""
+
+        def decorator(
+            func: Callable[..., Awaitable[Any]],
+        ) -> Callable[..., Awaitable[Any]]:
+            if self.allowlist and name not in self.allowlist:
+                raise ValueError(f"Tool '{name}' not allowed")
+            self._tools[name] = func
+            return func
+
+        return decorator
+
+    def bind(self, mcp: Any) -> None:
+        """Bind registered tools to an MCP server instance."""
+        for name, func in self._tools.items():
+            mcp.tool(name=name)(func)
+
+    def list_tools(self) -> list[str]:
+        """Return list of registered tool names."""
+        return list(self._tools.keys())

--- a/apps/mcp/tools/schemas.py
+++ b/apps/mcp/tools/schemas.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PingResponse(BaseModel):
+    """Response model for ping tool."""
+
+    message: str
+
+
+class RagSearchRequest(BaseModel):
+    """Request model for RAG search."""
+
+    query: str = Field(..., min_length=1)
+    top_k: int = Field(5, ge=1, le=50)
+
+
+class RagSearchResponse(BaseModel):
+    """Response model for RAG search results."""
+
+    answer: str
+    sources: list[str]
+
+
+class ToolsListResponse(BaseModel):
+    """Response model listing available tools."""
+
+    tools: list[str]
+
+
+class HealthResponse(BaseModel):
+    """Health check response model."""
+
+    status: str

--- a/tests/mcp/test_tools_middleware.py
+++ b/tests/mcp/test_tools_middleware.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+
+from apps.mcp.tools.middleware import (
+    RateLimiter,
+    RateLimitError,
+    ToolExecutionError,
+    scrub_log,
+    with_middleware,
+)
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_per_tool() -> None:
+    limiter = RateLimiter(per_tool_limit=1, global_limit=10)
+    await limiter.check("a")
+    with pytest.raises(RateLimitError):
+        await limiter.check("a")
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_global() -> None:
+    limiter = RateLimiter(per_tool_limit=10, global_limit=1)
+    await limiter.check("a")
+    with pytest.raises(RateLimitError):
+        await limiter.check("b")
+
+
+def test_scrub_log_masks_secrets() -> None:
+    secret = "A" * 32
+    masked = scrub_log(f"token:{secret}")
+    assert secret not in masked
+
+
+@pytest.mark.asyncio
+async def test_with_middleware_success() -> None:
+    limiter = RateLimiter()
+
+    @with_middleware("ok", 1, limiter)
+    async def ping(ctx: object) -> str:
+        return "pong"
+
+    assert await ping(None) == "pong"
+
+
+@pytest.mark.asyncio
+async def test_with_middleware_timeout() -> None:
+    limiter = RateLimiter()
+
+    @with_middleware("slow", 0.1, limiter)
+    async def slow(ctx: object) -> str:
+        await asyncio.sleep(0.2)
+        return "done"
+
+    with pytest.raises(ToolExecutionError):
+        await slow(None)
+
+
+@pytest.mark.asyncio
+async def test_with_middleware_rate_limit() -> None:
+    limiter = RateLimiter(per_tool_limit=1, global_limit=1)
+
+    @with_middleware("limited", 1, limiter)
+    async def ping(ctx: object) -> str:
+        return "pong"
+
+    await ping(None)
+    with pytest.raises(RateLimitError):
+        await ping(None)

--- a/tests/mcp/test_tools_registry.py
+++ b/tests/mcp/test_tools_registry.py
@@ -1,0 +1,41 @@
+from typing import Any, Callable
+
+import pytest
+
+from apps.mcp.tools.registry import ToolRegistry
+
+
+@pytest.mark.asyncio
+async def test_registry_register_and_bind() -> None:
+    registry = ToolRegistry()
+
+    @registry.register("ping")
+    async def ping(ctx: object) -> str:
+        return "pong"
+
+    class DummyMCP:
+        def __init__(self) -> None:
+            self.registered: dict[str, Callable[..., Any]] = {}
+
+        def tool(self, name: str) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+            def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+                self.registered[name] = func
+                return func
+
+            return decorator
+
+    mcp = DummyMCP()
+    registry.bind(mcp)
+    assert "ping" in registry.list_tools()
+    assert "ping" in mcp.registered
+
+
+@pytest.mark.asyncio
+async def test_registry_allowlist() -> None:
+    registry = ToolRegistry(allowlist={"allowed"})
+
+    with pytest.raises(ValueError):
+
+        @registry.register("blocked")
+        async def blocked(ctx: object) -> str:
+            return "nope"

--- a/tests/mcp/test_tools_schemas.py
+++ b/tests/mcp/test_tools_schemas.py
@@ -1,0 +1,36 @@
+import pytest
+
+from apps.mcp.tools.schemas import (
+    HealthResponse,
+    PingResponse,
+    RagSearchRequest,
+    RagSearchResponse,
+    ToolsListResponse,
+)
+
+
+def test_ping_response() -> None:
+    model = PingResponse(message="pong")
+    assert model.message == "pong"
+
+
+def test_rag_search_request_validation() -> None:
+    with pytest.raises(ValueError):
+        RagSearchRequest(query="", top_k=0)
+    req = RagSearchRequest(query="q", top_k=5)
+    assert req.top_k == 5
+
+
+def test_rag_search_response() -> None:
+    resp = RagSearchResponse(answer="a", sources=["s"])
+    assert resp.sources == ["s"]
+
+
+def test_tools_list_response() -> None:
+    resp = ToolsListResponse(tools=["t"])
+    assert resp.tools == ["t"]
+
+
+def test_health_response() -> None:
+    resp = HealthResponse(status="ok")
+    assert resp.status == "ok"


### PR DESCRIPTION
## Summary
- add `ToolRegistry` for managing MCP tools
- define Pydantic schemas for MCP tool I/O
- implement middleware with rate limiting, logging, and timeout

## Testing
- `flake8 --max-line-length=100 apps/mcp/tools tests/mcp/test_tools_registry.py tests/mcp/test_tools_middleware.py tests/mcp/test_tools_schemas.py`
- `mypy apps/mcp/tools tests/mcp/test_tools_registry.py tests/mcp/test_tools_middleware.py tests/mcp/test_tools_schemas.py`
- `bandit -r apps/mcp/tools`
- `pytest tests/mcp/test_tools_registry.py tests/mcp/test_tools_middleware.py tests/mcp/test_tools_schemas.py -v --cov=apps/mcp/tools`
- `pytest tests -v --cov=apps` *(fails: Module name clash during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a86461c0408322b101248e8f86343c