### PR TITLE
feat: add mcp system and rag tools

### DIFF
--- a/apps/mcp/tools/ping.py
+++ b/apps/mcp/tools/ping.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import Context
+
+from .middleware import with_middleware
+from .registry import registry
+from .schemas import PingResponse
+
+logger = logging.getLogger(__name__)
+
+
+class PingError(Exception):
+    """Raised when ping tool fails."""
+
+
+@registry.register("ping")
+@with_middleware("ping", timeout_s=2)
+async def ping_tool(ctx: Context[Any, Any, Any]) -> PingResponse:
+    """Simple health check tool."""
+    try:
+        await ctx.info("ping received")
+        logger.info("responding to ping")
+        return PingResponse(message="pong")
+    except Exception as exc:  # pragma: no cover - unexpected
+        await ctx.error(f"Ping failed: {exc}")
+        raise PingError(str(exc)) from exc

--- a/apps/mcp/tools/rag_search.py
+++ b/apps/mcp/tools/rag_search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import httpx
+from mcp.server.fastmcp import Context
+
+from .middleware import with_middleware
+from .registry import registry
+from .schemas import RagSearchRequest, RagSearchResponse
+
+logger = logging.getLogger(__name__)
+
+
+class RagSearchError(Exception):
+    """Raised when RAG search fails."""
+
+
+@registry.register("rag_search")
+@with_middleware("rag_search", timeout_s=8)
+async def rag_search_tool(
+    ctx: Context[Any, Any, Any], request: RagSearchRequest
+) -> RagSearchResponse:
+    """Perform RAG search via external API."""
+    api_url = os.getenv("RAG_API_URL")
+    if not api_url:
+        raise RagSearchError("RAG_API_URL not set")
+    headers: dict[str, str] = {}
+    api_key = os.getenv("RAG_API_KEY")
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    payload = request.model_dump()
+    for attempt in range(3):
+        try:
+            async with httpx.AsyncClient(timeout=5.0) as client:
+                resp = await client.post(api_url, json=payload, headers=headers)
+                resp.raise_for_status()
+                data: Any = resp.json()
+                result = RagSearchResponse.model_validate(data)
+                await ctx.info("rag search success")
+                return result
+        except Exception as exc:
+            wait = 2**attempt
+            logger.warning("rag search attempt %s failed: %s", attempt + 1, exc)
+            if attempt == 2:
+                await ctx.error(f"RAG search failed: {exc}")
+                raise RagSearchError(str(exc)) from exc
+            await asyncio.sleep(wait)
+    raise RagSearchError("unknown error")  # pragma: no cover

--- a/apps/mcp/tools/registry.py
+++ b/apps/mcp/tools/registry.py
@@ -33,3 +33,7 @@ class ToolRegistry:
     def list_tools(self) -> list[str]:
         """Return list of registered tool names."""
         return list(self._tools.keys())
+
+
+# Global registry instance for tool registration
+registry = ToolRegistry()

--- a/apps/mcp/tools/system.py
+++ b/apps/mcp/tools/system.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from mcp.server.fastmcp import Context
+
+from .middleware import with_middleware
+from .registry import registry
+from .schemas import HealthResponse, ToolsListResponse
+
+logger = logging.getLogger(__name__)
+
+
+class ToolsListError(Exception):
+    """Raised when tools_list fails."""
+
+
+class ToolsHealthError(Exception):
+    """Raised when tools_health fails."""
+
+
+@registry.register("tools_list")
+@with_middleware("tools_list", timeout_s=2)
+async def tools_list(ctx: Context[Any, Any, Any]) -> ToolsListResponse:
+    """Return list of registered tools."""
+    try:
+        tools = registry.list_tools()
+        await ctx.info("listed tools")
+        return ToolsListResponse(tools=tools)
+    except Exception as exc:  # pragma: no cover - unexpected
+        await ctx.error(f"Tools list failed: {exc}")
+        raise ToolsListError(str(exc)) from exc
+
+
+@registry.register("tools_health")
+@with_middleware("tools_health", timeout_s=2)
+async def tools_health(ctx: Context[Any, Any, Any]) -> HealthResponse:
+    """Simple health check."""
+    try:
+        await ctx.info("health ok")
+        return HealthResponse(status="ok")
+    except Exception as exc:  # pragma: no cover - unexpected
+        await ctx.error(f"Health check failed: {exc}")
+        raise ToolsHealthError(str(exc)) from exc

--- a/tests/mcp/test_tools_ping.py
+++ b/tests/mcp/test_tools_ping.py
@@ -1,0 +1,23 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from apps.mcp.tools.middleware import ToolExecutionError
+from apps.mcp.tools.ping import ping_tool
+
+
+@pytest.mark.asyncio
+async def test_ping_tool_success() -> None:
+    ctx = AsyncMock()
+    resp = await ping_tool(ctx)
+    assert resp.message == "pong"
+    ctx.info.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_ping_tool_error() -> None:
+    ctx = AsyncMock()
+    ctx.info.side_effect = Exception("boom")
+    with pytest.raises(ToolExecutionError):
+        await ping_tool(ctx)
+    ctx.error.assert_called()

--- a/tests/mcp/test_tools_rag_search.py
+++ b/tests/mcp/test_tools_rag_search.py
@@ -1,0 +1,39 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from apps.mcp.tools.middleware import ToolExecutionError
+from apps.mcp.tools.rag_search import rag_search_tool
+from apps.mcp.tools.schemas import RagSearchRequest
+
+
+@pytest.mark.asyncio
+async def test_rag_search_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAG_API_URL", "http://rag")
+    ctx = AsyncMock()
+    request = RagSearchRequest(query="test")
+    mock_resp = Mock()
+    mock_resp.json.return_value = {"answer": "hi", "sources": ["doc1"]}
+    mock_resp.raise_for_status = Mock()
+    mock_ac = AsyncMock()
+    mock_ac.post.return_value = mock_resp
+    with patch("httpx.AsyncClient") as client:
+        client.return_value.__aenter__.return_value = mock_ac
+        result = await rag_search_tool(ctx, request)
+    assert result.answer == "hi"
+    assert result.sources == ["doc1"]
+    ctx.info.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_rag_search_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RAG_API_URL", "http://rag")
+    ctx = AsyncMock()
+    request = RagSearchRequest(query="fail")
+    mock_ac = AsyncMock()
+    mock_ac.post.side_effect = Exception("boom")
+    with patch("httpx.AsyncClient") as client:
+        client.return_value.__aenter__.return_value = mock_ac
+        with pytest.raises(ToolExecutionError):
+            await rag_search_tool(ctx, request)
+    ctx.error.assert_called()

--- a/tests/mcp/test_tools_system.py
+++ b/tests/mcp/test_tools_system.py
@@ -1,0 +1,43 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import apps.mcp.tools.ping  # noqa: F401
+from apps.mcp.tools.middleware import ToolExecutionError
+from apps.mcp.tools.system import tools_health, tools_list
+
+
+@pytest.mark.asyncio
+async def test_tools_list_success() -> None:
+    ctx = AsyncMock()
+    resp = await tools_list(ctx)
+    assert "ping" in resp.tools
+    ctx.info.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_tools_list_error() -> None:
+    ctx = AsyncMock()
+    with patch(
+        "apps.mcp.tools.system.registry.list_tools", side_effect=Exception("fail")
+    ):
+        with pytest.raises(ToolExecutionError):
+            await tools_list(ctx)
+    ctx.error.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_tools_health_success() -> None:
+    ctx = AsyncMock()
+    resp = await tools_health(ctx)
+    assert resp.status == "ok"
+    ctx.info.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_tools_health_error() -> None:
+    ctx = AsyncMock()
+    ctx.info.side_effect = Exception("boom")
+    with pytest.raises(ToolExecutionError):
+        await tools_health(ctx)
+    ctx.error.assert_called()


### PR DESCRIPTION
## Summary
- add ping, rag_search, and system MCP tools with middleware and registry support
- add retrying RAG search using external API and environment configuration
- provide tests for new MCP tools

## Testing
- `mypy apps/mcp/tools`
- `pytest tests/mcp/test_tools_ping.py tests/mcp/test_tools_rag_search.py tests/mcp/test_tools_system.py -v --cov=apps/mcp/tools`
- `flake8 apps/mcp/tools tests/mcp` *(command not found)*
- `bandit -r apps/mcp/tools` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a86641fc008322962b1beb6e0c0a7c