### PR TITLE
refactor: centralize MCP tool registration

### DIFF
--- a/apps/mcp/server.py
+++ b/apps/mcp/server.py
@@ -1,28 +1,40 @@
+"""MCP server entry point for AgentFlow.
+
+Imports tool modules so each registers itself with the global registry.
+The registry is then bound to the ``FastMCP`` instance, and middleware
+wrapping is applied within the tool modules for logging, timeouts, and
+rate limiting.
+"""
+
 from __future__ import annotations
 
 import asyncio
 import os
-from typing import Any
 
 from loguru import logger
-from mcp.server.fastmcp import Context, FastMCP
+from mcp.server.fastmcp import FastMCP
+
+# Import tools and registry. Tools register themselves on import via the
+# registry decorator and apply middleware from ``tools.middleware``.
+try:  # pragma: no cover - fallback for script execution
+    from apps.mcp.tools import ping, rag_search, system  # noqa: F401
+    from apps.mcp.tools.registry import registry
+except ModuleNotFoundError:  # pragma: no cover
+    from tools import ping, rag_search, system  # type: ignore  # noqa: F401
+    from tools.registry import registry  # type: ignore
 
 mcp = FastMCP("AgentFlow MCP", debug=False, log_level="INFO")
-
-
-@mcp.tool()
-async def ping(ctx: Context[Any, Any, Any]) -> str:
-    """Health check tool."""
-    await ctx.info("pong")
-    return "pong"
+# Bind all tools registered in the global registry to this MCP instance.
+registry.bind(mcp)
 
 
 def run_stdio() -> None:  # pragma: no cover
+    """Run MCP server using STDIO transport."""
     mcp.run()
 
 
 async def run_http() -> None:
-    """Stub HTTP transport."""
+    """Stub HTTP transport for future extension."""
     logger.info("HTTP transport not yet implemented")
 
 

--- a/apps/mcp/tools/middleware.py
+++ b/apps/mcp/tools/middleware.py
@@ -81,6 +81,7 @@ def with_middleware(
                 logger.exception(scrub_log(f"error {name}: {exc}"))
                 raise ToolExecutionError(str(exc)) from exc
 
+        wrapper.__globals__.update(func.__globals__)  # type: ignore[attr-defined]
         return wrapper
 
     return decorator

--- a/tests/mcp/test_server.py
+++ b/tests/mcp/test_server.py
@@ -8,7 +8,8 @@ import pytest
 from mcp.server.fastmcp import Context
 from mcp.server.fastmcp.exceptions import ToolError
 
-from apps.mcp.server import mcp, ping, run_http
+from apps.mcp.server import mcp, run_http
+from apps.mcp.tools.ping import ping_tool
 
 
 @pytest.fixture
@@ -22,17 +23,18 @@ def mock_context() -> AsyncMock:
 
 @pytest.mark.asyncio
 async def test_tool_discovery() -> None:
-    """Tools should include the ping command."""
+    """Tools should include registered commands."""
     tools = await mcp.list_tools()
-    assert any(tool.name == "ping" for tool in tools)
+    names = {tool.name for tool in tools}
+    assert {"ping", "rag_search", "tools_list", "tools_health"}.issubset(names)
 
 
 @pytest.mark.asyncio
 async def test_ping_execution(mock_context: AsyncMock) -> None:
     """Ping tool should return pong and log info."""
-    result = await ping(mock_context)
-    assert result == "pong"
-    mock_context.info.assert_called_with("pong")
+    result = await ping_tool(mock_context)
+    assert result.message == "pong"
+    mock_context.info.assert_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- use registry to bind ping, rag_search, and system tools to FastMCP
- copy original globals in middleware so wrapped tools keep context annotations
- test MCP server tool discovery and ping execution

## Testing
- `black apps/mcp/server.py tests/mcp/test_server.py apps/mcp/tools/middleware.py`
- `isort apps/mcp/server.py tests/mcp/test_server.py apps/mcp/tools/middleware.py`
- `flake8 apps/mcp/server.py tests/mcp/test_server.py apps/mcp/tools/middleware.py`
- `python -m mypy apps/mcp/server.py tests/mcp/test_server.py --follow-imports=skip`
- `python -m mypy apps/mcp/tools/middleware.py --follow-imports=skip`
- `bandit -r apps/mcp`
- `pytest tests/mcp/test_server.py tests/mcp/test_tools_ping.py tests/mcp/test_tools_registry.py tests/mcp/test_tools_rag_search.py tests/mcp/test_tools_system.py -v --cov=apps`


------
https://chatgpt.com/codex/tasks/task_e_68a8690796448322bd64a3616498c2f6