### PR TITLE
feat(api): enforce strict pydantic models

### DIFF
--- a/apps/api/app/core/settings.py
+++ b/apps/api/app/core/settings.py
@@ -8,7 +8,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class Settings(BaseSettings):
     """Pydantic settings for core configuration."""
 
-    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+    model_config = SettingsConfigDict(env_file=".env", extra="forbid")
 
     app_name: str = "AgentFlow API"
     secret_key: str

--- a/apps/api/app/models/auth.py
+++ b/apps/api/app/models/auth.py
@@ -2,10 +2,12 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr
+from pydantic import EmailStr
+
+from .base import StrictModel
 
 
-class UserCreate(BaseModel):
+class UserCreate(StrictModel):
     email: EmailStr
     password: str
 
@@ -14,32 +16,32 @@ class LoginRequest(UserCreate):
     otp_code: str
 
 
-class RefreshRequest(BaseModel):
+class RefreshRequest(StrictModel):
     refresh_token: str
 
 
-class TokenResponse(BaseModel):
+class TokenResponse(StrictModel):
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
 
 
-class ResetRequest(BaseModel):
+class ResetRequest(StrictModel):
     email: EmailStr
 
 
-class ResetResponse(BaseModel):
+class ResetResponse(StrictModel):
     reset_token: str
 
 
-class UserInfo(BaseModel):
+class UserInfo(StrictModel):
     email: EmailStr
 
 
-class RegisterResponse(BaseModel):
+class RegisterResponse(StrictModel):
     otp_secret: str
     status: str = "ok"
 
 
-class LogoutResponse(BaseModel):
+class LogoutResponse(StrictModel):
     status: Literal["ok"] = "ok"

--- a/apps/api/app/models/base.py
+++ b/apps/api/app/models/base.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")

--- a/apps/api/app/models/cache.py
+++ b/apps/api/app/models/cache.py
@@ -1,9 +1,9 @@
 """Pydantic models for cache operations."""
 
-from pydantic import BaseModel
+from .base import StrictModel
 
 
-class CacheEntry(BaseModel):
+class CacheEntry(StrictModel):
     """Represents a cached key-value pair."""
 
     key: str
@@ -11,7 +11,7 @@ class CacheEntry(BaseModel):
     cached: bool
 
 
-class CachePostResponse(BaseModel):
+class CachePostResponse(StrictModel):
     """Response model for cached POST requests."""
 
     id: str

--- a/apps/api/app/models/health.py
+++ b/apps/api/app/models/health.py
@@ -2,10 +2,10 @@
 
 from typing import Literal
 
-from pydantic import BaseModel
+from .base import StrictModel
 
 
-class HealthStatus(BaseModel):
+class HealthStatus(StrictModel):
     """Represents the health status of the service."""
 
     status: Literal["ok", "ready"]

--- a/apps/api/app/models/rag.py
+++ b/apps/api/app/models/rag.py
@@ -4,16 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import BaseModel
+from .base import StrictModel
 
 
-class RAGSearchResponse(BaseModel):
+class RAGSearchResponse(StrictModel):
     """Schema for responses returned by RAG search."""
 
     results: list[Any]
 
 
-class DocumentUploadResponse(BaseModel):
+class DocumentUploadResponse(StrictModel):
     """Schema for responses after uploading a document."""
 
     ok: bool

--- a/apps/api/app/models/schemas.py
+++ b/apps/api/app/models/schemas.py
@@ -1,19 +1,21 @@
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, field_validator
+from pydantic import field_validator
+
+from .base import StrictModel
 
 
-class MemoryItem(BaseModel):
+class MemoryItem(StrictModel):
     id: str | None = None
     text: str
     scope: Literal["user", "agent", "session", "global"] = "user"
     user_id: str | None = None
     agent_id: str | None = None
     run_id: str | None = None
-    metadata: dict | None = None
+    metadata: dict[str, Any] | None = None
 
 
-class RAGQuery(BaseModel):
+class RAGQuery(StrictModel):
     query: str
     filters: dict[str, str] | None = None
     vector: bool = True
@@ -23,19 +25,25 @@ class RAGQuery(BaseModel):
 
     @field_validator("filters")
     @classmethod
-    def validate_filters(cls, value: dict[str, str] | None) -> dict[str, str] | None:
+    def validate_filters(
+        cls,
+        value: dict[str, str] | None,
+    ) -> dict[str, str] | None:
         if value is None:
             return None
         if any(
-            not isinstance(k, str) or not isinstance(v, str) for k, v in value.items()
+            (
+                not isinstance(k, str) or not isinstance(v, str)
+                for k, v in value.items()
+            ),
         ):
             raise ValueError("filters must be string key-value pairs")
         return value
 
 
-class AgentPrompt(BaseModel):
+class AgentPrompt(StrictModel):
     prompt: str
 
 
-class AgentRunResponse(BaseModel):
+class AgentRunResponse(StrictModel):
     result: str

--- a/tests/api/test_strict_models.py
+++ b/tests/api/test_strict_models.py
@@ -1,0 +1,19 @@
+import pytest
+from pydantic import ValidationError
+
+from apps.api.app.models.auth import UserCreate
+from apps.api.app.models.schemas import RAGQuery
+
+
+def test_user_create_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        UserCreate(
+            email="user@example.com",
+            password="secret",
+            unknown="value",
+        )
+
+
+def test_rag_query_rejects_unknown_field() -> None:
+    with pytest.raises(ValidationError):
+        RAGQuery(query="hello", unknown=True)


### PR DESCRIPTION
## Summary
- add StrictModel base to forbid unknown fields
- update API models to inherit StrictModel
- tighten settings extra handling and add validation tests

## Testing
- `flake8 apps/api/app/models/base.py apps/api/app/models/auth.py apps/api/app/models/cache.py apps/api/app/models/health.py apps/api/app/models/rag.py apps/api/app/models/schemas.py apps/api/app/core/settings.py tests/api/test_strict_models.py`
- `mypy apps/api/app/models/base.py apps/api/app/models/auth.py apps/api/app/models/cache.py apps/api/app/models/health.py apps/api/app/models/rag.py apps/api/app/models/schemas.py apps/api/app/core/settings.py`
- `bandit -r apps/`
- `pytest tests/ -v --cov=apps` *(fails: import conflict between test_agents modules)*
- `pytest tests/api/test_strict_models.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68a885bc51c48322baa5294f11dc9319