### PR TITLE
fix: add ToolTimeout for middleware timeouts

### DIFF
--- a/apps/mcp/tools/middleware.py
+++ b/apps/mcp/tools/middleware.py
@@ -21,6 +21,10 @@ class ToolExecutionError(Exception):
     """Raised when tool execution fails."""
 
 
+class ToolTimeout(ToolExecutionError):
+    """Raised when a tool exceeds its timeout."""
+
+
 class RateLimiter:
     """Simple sliding-window rate limiter."""
 
@@ -76,7 +80,7 @@ def with_middleware(
                 raise
             except TimeoutError as exc:
                 logger.error(scrub_log(f"timeout {name}"))
-                raise ToolExecutionError("timeout") from exc
+                raise ToolTimeout("timeout") from exc
             except Exception as exc:
                 logger.exception(scrub_log(f"error {name}: {exc}"))
                 raise ToolExecutionError(str(exc)) from exc

--- a/tests/mcp/test_tools_middleware.py
+++ b/tests/mcp/test_tools_middleware.py
@@ -5,7 +5,7 @@ import pytest
 from apps.mcp.tools.middleware import (
     RateLimiter,
     RateLimitError,
-    ToolExecutionError,
+    ToolTimeout,
     scrub_log,
     with_middleware,
 )
@@ -53,7 +53,7 @@ async def test_with_middleware_timeout() -> None:
         await asyncio.sleep(0.2)
         return "done"
 
-    with pytest.raises(ToolExecutionError):
+    with pytest.raises(ToolTimeout):
         await slow(None)
 
 


### PR DESCRIPTION
## Summary
- add ToolTimeout exception for timed-out tools
- raise ToolTimeout from middleware
- test middleware timeout behavior

## Testing
- `python -m flake8 --max-line-length 100 apps/mcp/tools/middleware.py tests/mcp/test_tools_middleware.py`
- `python -m mypy apps/mcp/tools/middleware.py tests/mcp/test_tools_middleware.py`
- `bandit -r apps/mcp/tools -q`
- `pytest tests/mcp/test_tools_middleware.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68a887bbdffc8322ab899d17838dbc32