### PR TITLE
feat: redact secrets from structured logs

### DIFF
--- a/tests/api/test_logging.py
+++ b/tests/api/test_logging.py
@@ -1,0 +1,14 @@
+import json
+from typing import Any
+
+from apps.api.app.utils.logging import logger, setup_logging
+
+
+def test_secret_redaction(capsys: Any) -> None:
+    setup_logging()
+    secret = "a" * 32
+    logger.info(f"Using API key {secret}")
+    output = capsys.readouterr().out
+    record = json.loads(output)
+    assert "***" in record["record"]["message"]
+    assert secret not in record["record"]["message"]


### PR DESCRIPTION
## Summary
- redact API keys in log messages using regex filter
- add tests verifying log redaction of secret-like strings

## Testing
- `flake8 apps/api/app/utils/logging.py tests/api/test_logging.py`
- `mypy apps/api/app/utils/logging.py tests/api/test_logging.py`
- `bandit -r apps/`
- `pytest tests/api/test_logging.py -v --cov=apps/api/app/utils/logging.py`


------
https://chatgpt.com/codex/tasks/task_e_68a893abb5208322b247d8c9deaa867f