### PR TITLE
feat: add async R2R client with retries and telemetry

### DIFF
--- a/packages/__init__.py
+++ b/packages/__init__.py
@@ -1,0 +1,1 @@
+"""Utility namespace for internal packages."""

--- a/packages/r2r/__init__.py
+++ b/packages/r2r/__init__.py
@@ -1,0 +1,27 @@
+from .client import R2RClient
+from .config import R2RConfig, load_config
+from .errors import (
+    AuthError,
+    BadRequestError,
+    R2RError,
+    RateLimitedError,
+    TimeoutError,
+    UnavailableError,
+)
+from .models import DocV1, IndexAckV1, SearchHitV1, SearchResultV1
+
+__all__ = [
+    "R2RClient",
+    "R2RConfig",
+    "load_config",
+    "DocV1",
+    "SearchHitV1",
+    "SearchResultV1",
+    "IndexAckV1",
+    "R2RError",
+    "AuthError",
+    "RateLimitedError",
+    "UnavailableError",
+    "TimeoutError",
+    "BadRequestError",
+]

--- a/packages/r2r/client.py
+++ b/packages/r2r/client.py
@@ -1,10 +1,134 @@
-import os
-from r2r import R2RClient
+from __future__ import annotations
 
-def make_client() -> R2RClient:
-    base = os.getenv("R2R_BASE_URL", "http://localhost:7272")
-    api_key = os.getenv("R2R_API_KEY")
-    if api_key:
-        os.environ["R2R_API_KEY"] = api_key
-        return R2RClient()
-    return R2RClient(base_url=base)
+import asyncio
+import random
+import time
+from typing import Any
+
+import httpx
+from opentelemetry import trace
+
+from .config import R2RConfig, load_config
+from .errors import (
+    AuthError,
+    BadRequestError,
+    R2RError,
+    RateLimitedError,
+    TimeoutError,
+    UnavailableError,
+)
+from .models import DocV1, IndexAckV1, SearchResultV1
+
+tracer = trace.get_tracer(__name__)
+
+
+class R2RClient:
+    def __init__(
+        self,
+        config: R2RConfig | None = None,
+        *,
+        timeout: float = 10.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._config = config or load_config()
+        self._timeout = timeout
+        self._client = httpx.AsyncClient(
+            base_url=self._config.base_url,
+            headers=self._headers(),
+            transport=transport,
+        )
+        self._retries = 3
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Accept": "application/json"}
+        if self._config.api_key:
+            headers["Authorization"] = f"Bearer {self._config.api_key}"
+        return headers
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json: Any | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        last_err: Exception | None = None
+        for attempt in range(1, self._retries + 1):
+            start = time.perf_counter()
+            span = tracer.start_span("r2r.request")
+            span.set_attribute("path", path)
+            span.set_attribute("attempt", attempt)
+            try:
+                response = await self._client.request(
+                    method,
+                    path,
+                    json=json,
+                    headers=headers,
+                    timeout=self._timeout,
+                )
+                status = response.status_code
+                span.set_attribute("status_code", status)
+                span.set_attribute("duration_ms", (time.perf_counter() - start) * 1000)
+                if 200 <= status < 300:
+                    span.end()
+                    return response.json()
+                last_err = self._map_error(status)
+                span.end()
+                if status < 500 and status != 429:
+                    break
+            except httpx.TimeoutException as exc:
+                span.set_attribute("status_code", 0)
+                span.set_attribute("duration_ms", (time.perf_counter() - start) * 1000)
+                last_err = TimeoutError(str(exc))
+                span.end()
+            except httpx.HTTPError as exc:  # pragma: no cover - network errors
+                span.set_attribute("status_code", 0)
+                span.set_attribute("duration_ms", (time.perf_counter() - start) * 1000)
+                last_err = UnavailableError(str(exc))
+                span.end()
+            if attempt == self._retries:
+                break
+            await asyncio.sleep(self._backoff(attempt))
+        if last_err is None:
+            raise UnavailableError("Unknown error")
+        raise last_err
+
+    def _map_error(self, status: int) -> R2RError:
+        if status == 400:
+            return BadRequestError("Bad request")
+        if status in {401, 403}:
+            return AuthError("Unauthorized")
+        if status == 429:
+            return RateLimitedError("Rate limited")
+        if status in {408, 504}:
+            return TimeoutError("Request timeout")
+        return UnavailableError("Service unavailable")
+
+    def _backoff(self, attempt: int) -> float:
+        return min(2 ** (attempt - 1), 10) + random.random()  # nosec B311
+
+    async def search(self, query: str, top_k: int = 10) -> SearchResultV1:
+        if not query.strip():
+            raise ValueError("query must not be empty")
+        if top_k <= 0:
+            raise ValueError("top_k must be positive")
+        data = await self._request(
+            "POST", "/search", json={"query": query, "top_k": top_k}
+        )
+        return SearchResultV1(**data)
+
+    async def index(self, doc: DocV1, idempotency_key: str | None = None) -> IndexAckV1:
+        headers = {}
+        if idempotency_key:
+            headers["Idempotency-Key"] = idempotency_key
+        data = await self._request(
+            "POST", "/index", json=doc.model_dump(), headers=headers
+        )
+        return IndexAckV1(**data)
+
+    async def close(self) -> None:
+        await self._client.aclose()
+
+
+__all__ = ["R2RClient"]

--- a/packages/r2r/config.py
+++ b/packages/r2r/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - py<3.11
+    import tomli as tomllib
+
+from pydantic import BaseModel
+
+
+class R2RConfig(BaseModel):
+    base_url: str = "http://localhost:7272"
+    api_key: str | None = None
+
+
+def load_config(path: str | None = None) -> R2RConfig:
+    env_path = os.getenv("R2R_CONFIG_PATH") or "infra/r2r.toml"
+    file_path = Path(path or env_path)
+    data: dict[str, Any] = {}
+    if file_path.exists():
+        with file_path.open("rb") as f:
+            data.update(tomllib.load(f))
+    env_base = os.getenv("R2R_BASE_URL")
+    env_key = os.getenv("R2R_API_KEY")
+    if env_base:
+        data["base_url"] = env_base
+    if env_key:
+        data["api_key"] = env_key
+    return R2RConfig(**data)
+
+
+__all__ = ["R2RConfig", "load_config"]

--- a/packages/r2r/errors.py
+++ b/packages/r2r/errors.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+
+class R2RError(Exception):
+    """Base exception for R2R client errors."""
+
+
+class AuthError(R2RError):
+    """Authentication failure."""
+
+
+class RateLimitedError(R2RError):
+    """Rate limit exceeded."""
+
+
+class UnavailableError(R2RError):
+    """Service unavailable or network error."""
+
+
+class TimeoutError(R2RError):
+    """Request timed out."""
+
+
+class BadRequestError(R2RError):
+    """Invalid request sent to server."""
+
+
+__all__ = [
+    "R2RError",
+    "AuthError",
+    "RateLimitedError",
+    "UnavailableError",
+    "TimeoutError",
+    "BadRequestError",
+]

--- a/packages/r2r/models.py
+++ b/packages/r2r/models.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class DocV1(BaseModel):
+    content: str
+    metadata: dict[str, Any] | None = None
+
+
+class SearchHitV1(BaseModel):
+    id: str
+    score: float
+    snippet: str
+
+
+class SearchResultV1(BaseModel):
+    hits: list[SearchHitV1] = Field(default_factory=list)
+
+
+class IndexAckV1(BaseModel):
+    id: str
+    status: str
+
+
+__all__ = [
+    "DocV1",
+    "SearchHitV1",
+    "SearchResultV1",
+    "IndexAckV1",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "SQLAlchemy>=2.0",
     "psycopg[binary]>=3.2",
     "httpx>=0.27",
+    "opentelemetry-api>=1.20",
     "r2r>=0.1.0",
     "loguru>=0.7.2",
     "langgraph>=0.1.0",

--- a/tests/r2r/test_client.py
+++ b/tests/r2r/test_client.py
@@ -1,0 +1,67 @@
+import httpx
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from packages.r2r.client import R2RClient
+from packages.r2r.config import R2RConfig
+from packages.r2r.errors import AuthError
+from packages.r2r.models import DocV1
+
+
+@pytest.fixture(autouse=True)
+def _tracer() -> InMemorySpanExporter:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+def _client(handler: httpx.MockTransport) -> R2RClient:
+    config = R2RConfig(base_url="http://test")
+    return R2RClient(config=config, transport=handler)
+
+
+@pytest.mark.asyncio
+async def test_search_success(_tracer: InMemorySpanExporter) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/search"
+        return httpx.Response(200, json={"hits": []})
+
+    client = _client(httpx.MockTransport(handler))
+    await client.search("query")
+    spans = _tracer.get_finished_spans()
+    assert spans and spans[0].name == "r2r.request"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_index_idempotency() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Idempotency-Key"] == "abc"
+        return httpx.Response(200, json={"id": "1", "status": "ok"})
+
+    client = _client(httpx.MockTransport(handler))
+    ack = await client.index(DocV1(content="x"), idempotency_key="abc")
+    assert ack.status == "ok"
+    await client.close()
+
+
+@pytest.mark.asyncio
+async def test_retry_and_error() -> None:
+    attempts = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            return httpx.Response(503)
+        return httpx.Response(401)
+
+    client = _client(httpx.MockTransport(handler))
+    with pytest.raises(AuthError):
+        await client.search("hello")
+    assert attempts["n"] == 2
+    await client.close()

--- a/tests/r2r/test_config.py
+++ b/tests/r2r/test_config.py
@@ -1,0 +1,10 @@
+import pytest
+
+from packages.r2r.config import R2RConfig, load_config
+
+
+def test_load_config_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("R2R_BASE_URL", "https://example.com")
+    monkeypatch.setenv("R2R_API_KEY", "token")
+    cfg = load_config(path="nonexistent.toml")
+    assert cfg == R2RConfig(base_url="https://example.com", api_key="token")


### PR DESCRIPTION
## Summary
- add typed async R2R client with retries, idempotency headers, and OpenTelemetry spans
- support env or TOML-based configuration and structured error taxonomy
- test client behavior for retries, idempotency, and config loading

## Testing
- `flake8 packages/r2r tests/r2r --max-line-length=100`
- `mypy packages/r2r tests/r2r`
- `bandit -r packages/r2r`
- `pytest tests/r2r -v --cov=packages/r2r --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a899bd31f08322a3d6763a62865e86