### PR TITLE
test: cover R2R client error mapping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.5",
     "pre-commit>=3.0",
+    "hypothesis>=6.112.1",
 ]
 
 [build-system]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ cryptography==45.0.6
 pytest==8.4.1
 pytest-asyncio==1.1.0
 respx==0.22.0
+hypothesis==6.112.1
 pyjwt==2.10.1
 tenacity==9.1.2
 fakeredis==2.31.0

--- a/tests/packages/test_r2r_client_errors.py
+++ b/tests/packages/test_r2r_client_errors.py
@@ -1,0 +1,50 @@
+import httpx
+import pytest
+import respx
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from packages.r2r.client import R2RClient
+from packages.r2r.config import R2RConfig
+from packages.r2r.errors import (
+    AuthError,
+    BadRequestError,
+    R2RError,
+    RateLimitedError,
+    TimeoutError,
+    UnavailableError,
+)
+
+
+def _expected_error(status: int) -> type[R2RError]:
+    if status == 400:
+        return BadRequestError
+    if status in {401, 403}:
+        return AuthError
+    if status == 429:
+        return RateLimitedError
+    if status in {408, 504}:
+        return TimeoutError
+    return UnavailableError
+
+
+status_strategy = st.one_of(
+    st.sampled_from([400, 401, 403, 408, 429]),
+    st.integers(min_value=500, max_value=599),
+)
+
+
+@respx.mock
+@settings(max_examples=25, deadline=None)
+@given(status=status_strategy)
+@pytest.mark.asyncio
+async def test_search_error_mapping(status: int) -> None:
+    respx.post("http://test/search").mock(
+        side_effect=lambda _request: httpx.Response(status)
+    )
+    client = R2RClient(config=R2RConfig(base_url="http://test"))
+    try:
+        with pytest.raises(_expected_error(status)):
+            await client.search("query")
+    finally:
+        await client.close()


### PR DESCRIPTION
## Summary
- add Hypothesis to testing dependencies
- verify R2R client maps HTTP errors to specific R2RError subclasses

## Testing
- `pytest tests/packages/test_r2r_client_errors.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8f7da571483228919900ff40d6e7f