### PR TITLE
fix: update ruff config to use lint section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ include = '\.pyi?$'
 [tool.ruff]
 target-version = "py310"
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings


### PR DESCRIPTION
## Summary
- move ruff `select` and `ignore` settings under `[tool.ruff.lint]`

## Testing
- `black apps/ tests/`
- `isort apps/ tests/`
- `flake8 apps/ tests/` *(fails: line too long and other style errors)*
- `mypy apps/` *(fails: missing opentelemetry and other stubs)*
- `bandit -r apps/`
- `pytest tests/ -v --cov=apps` *(fails: missing modules and import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f9b5e6fc832297aae3b970705aaf