### PR TITLE
fix: avoid shared default roles

### DIFF
--- a/tests/api/test_user_roles.py
+++ b/tests/api/test_user_roles.py
@@ -1,0 +1,11 @@
+from apps.api.app.dependencies import User
+
+
+def test_user_roles_are_independent() -> None:
+    """Ensure User instances do not share roles lists."""
+    user_one = User(sub="1")
+    user_two = User(sub="2")
+    user_one.roles.append("admin")
+
+    assert user_one.roles == ["admin"]
+    assert user_two.roles == []


### PR DESCRIPTION
## Summary
- ensure User roles field uses `Field(default_factory=list)` to prevent shared state
- add test verifying User instances maintain separate role lists

## Testing
- `isort --check-only apps/api/app/dependencies.py tests/api/test_user_roles.py`
- `black apps/api/app/dependencies.py tests/api/test_user_roles.py`
- `ruff check apps/api/app/dependencies.py tests/api/test_user_roles.py`
- `mypy apps/api/app/dependencies.py`
- `pytest tests/ -v --cov=apps --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'passlib')*
- `ENCRYPTION_KEY=foo pytest tests/api/test_user_roles.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68a99e977eb08322a3fb9eea40731c23