### PR TITLE
feat: add async database pooling utilities

### DIFF
--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -1,0 +1,56 @@
+"""Database connection utilities.
+
+This module provides access to a pooled SQLAlchemy AsyncEngine and session
+management helpers for the FastAPI application.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from .config import get_settings
+from .exceptions import AgentFlowError, ErrorCode
+
+_settings = get_settings()
+
+_engine: AsyncEngine = create_async_engine(
+    _settings.database_url,
+    pool_size=getattr(_settings, "db_pool_size", 5),
+    max_overflow=getattr(_settings, "db_max_overflow", 10),
+    pool_timeout=getattr(_settings, "db_pool_timeout", 30),
+    pool_recycle=getattr(_settings, "db_pool_recycle", 1_800),
+    pool_pre_ping=True,
+)
+
+_Session = async_sessionmaker(_engine, expire_on_commit=False)
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an asynchronous database session."""
+
+    try:
+        async with _Session() as session:
+            yield session
+    except OperationalError as exc:  # pragma: no cover - infrastructure
+        raise AgentFlowError("Database session error", ErrorCode.DOMAIN_ERROR) from exc
+
+
+def get_pool_status() -> dict[str, int]:
+    """Return current database pool metrics."""
+
+    pool: Any = _engine.pool
+    return {
+        "checked_in": pool.checkedin(),
+        "checked_out": pool.checkedout(),
+        "overflow": pool.overflow(),
+        "current_size": pool.size(),
+    }

--- a/tests/db/test_database.py
+++ b/tests/db/test_database.py
@@ -1,0 +1,98 @@
+"""Tests for database utilities."""
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+)
+from sqlalchemy.ext.asyncio import create_async_engine as sa_create_async_engine
+
+from apps.api.app.exceptions import AgentFlowError
+
+
+@pytest.mark.asyncio
+async def test_get_session_returns_async_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_session should yield an AsyncSession instance."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine",
+        lambda url, **_: sa_create_async_engine(url),
+    )
+    db = importlib.reload(importlib.import_module("apps.api.app.database"))
+
+    async for session in db.get_session():
+        assert isinstance(session, AsyncSession)
+
+
+@pytest.mark.asyncio
+async def test_get_session_wraps_operational_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_session should wrap OperationalError in AgentFlowError."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine",
+        lambda url, **_: sa_create_async_engine(url),
+    )
+    db = importlib.reload(importlib.import_module("apps.api.app.database"))
+
+    class FaultySession:
+        async def __aenter__(self) -> Any:
+            raise OperationalError("test", {}, None)
+
+        async def __aexit__(
+            self, exc_type, exc, tb
+        ) -> None:  # pragma: no cover - cleanup
+            return None
+
+    db._Session = lambda: FaultySession()
+
+    with pytest.raises(AgentFlowError):
+        async for _ in db.get_session():
+            pass
+
+
+def test_get_pool_status_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """get_pool_status should report pool metrics."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine",
+        lambda url, **_: sa_create_async_engine(url),
+    )
+    db = importlib.reload(importlib.import_module("apps.api.app.database"))
+
+    class FakePool:
+        def checkedin(self) -> int:  # pragma: no cover - simple accessor
+            return 0
+
+        def checkedout(self) -> int:  # pragma: no cover - simple accessor
+            return 0
+
+        def overflow(self) -> int:  # pragma: no cover - simple accessor
+            return 0
+
+        def size(self) -> int:  # pragma: no cover - simple accessor
+            return 0
+
+    db._engine.pool = FakePool()
+    status = db.get_pool_status()
+    assert set(status) == {"checked_in", "checked_out", "overflow", "current_size"}


### PR DESCRIPTION
## Summary
- add async SQLAlchemy engine with configurable pool settings
- expose `get_session` and `get_pool_status` helpers
- cover database helpers with unit tests

## Testing
- `ruff check apps/api/app/database.py tests/db/test_database.py`
- `mypy apps/api/app/database.py`
- `pytest tests/db/test_database.py -v --cov=apps/api/app/database.py --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a9a9ccd4a8832287de0f8e10eec4f2