### PR TITLE
feat: add database pool configuration settings

### DIFF
--- a/apps/api/app/core/settings.py
+++ b/apps/api/app/core/settings.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -14,6 +15,19 @@ class Settings(BaseSettings):
     secret_key: str
     openapi_url: str = "/openapi.json"
     database_url: str
+    database_pool_size: int = Field(
+        default=10, description="Size of the database connection pool."
+    )
+    database_pool_max_overflow: int = Field(
+        default=20, description="Extra connections allowed beyond the pool size."
+    )
+    database_pool_timeout: float = Field(
+        default=30.0,
+        description="Seconds to wait for a connection from the pool before timing out.",
+    )
+    database_pool_recycle: int = Field(
+        default=1800, description="Seconds after which connections are recycled."
+    )
     redis_url: str
     qdrant_url: str
     r2r_base_url: str = "http://localhost:7272"

--- a/tests/test_database_pool_settings.py
+++ b/tests/test_database_pool_settings.py
@@ -1,0 +1,56 @@
+"""Tests for database pool settings environment overrides and defaults."""
+
+import pytest
+
+from apps.api.app import config
+
+
+@pytest.fixture(autouse=True)
+def baseline_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide required base environment variables for settings."""
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://localhost/test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+
+
+@pytest.mark.parametrize(
+    "env_name, attr, expected",
+    [
+        ("DATABASE_POOL_SIZE", "database_pool_size", 10),
+        ("DATABASE_POOL_MAX_OVERFLOW", "database_pool_max_overflow", 20),
+        ("DATABASE_POOL_TIMEOUT", "database_pool_timeout", 30.0),
+        ("DATABASE_POOL_RECYCLE", "database_pool_recycle", 1800),
+    ],
+)
+def test_database_pool_defaults(
+    monkeypatch: pytest.MonkeyPatch, env_name: str, attr: str, expected: int | float
+) -> None:
+    """Should use default when env var is unset."""
+    monkeypatch.delenv(env_name, raising=False)
+    config.get_settings.cache_clear()
+    settings = config.get_settings()
+    assert getattr(settings, attr) == expected
+
+
+@pytest.mark.parametrize(
+    "env_name, value, attr, expected",
+    [
+        ("DATABASE_POOL_SIZE", "15", "database_pool_size", 15),
+        ("DATABASE_POOL_MAX_OVERFLOW", "25", "database_pool_max_overflow", 25),
+        ("DATABASE_POOL_TIMEOUT", "40", "database_pool_timeout", 40.0),
+        ("DATABASE_POOL_RECYCLE", "3600", "database_pool_recycle", 3600),
+    ],
+)
+def test_database_pool_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    value: str,
+    attr: str,
+    expected: int | float,
+) -> None:
+    """Should read env var values when provided."""
+    monkeypatch.setenv(env_name, value)
+    config.get_settings.cache_clear()
+    settings = config.get_settings()
+    assert getattr(settings, attr) == expected


### PR DESCRIPTION
## Summary
- add database connection pool settings with env overrides
- test database pool defaults and environment overrides

## Testing
- `black apps/api/app/core/settings.py tests/test_database_pool_settings.py`
- `isort --check apps/api/app/core/settings.py tests/test_database_pool_settings.py`
- `ruff check apps/api/app/core/settings.py tests/test_database_pool_settings.py`
- `mypy apps/` *(fails: missing libraries and typing issues)*
- `bandit -r apps/`
- `pytest tests/test_database_pool_settings.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68a9ac1d25648322ae5d697e823ce3c0