### PR TITLE
refactor: delegate session handling to database module

### DIFF
--- a/apps/api/app/db/session.py
+++ b/apps/api/app/db/session.py
@@ -1,20 +1,14 @@
-"""Database session utilities."""
+"""Database session compatibility layer."""
 
-from collections.abc import AsyncGenerator
+from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from ..config import get_settings
-from ..exceptions import AgentFlowError
+from ..database import _engine as _engine_instance
+from ..database import _Session as _session_factory
+from ..database import get_session
 
-_engine = create_async_engine(get_settings().database_url, future=True)
-_Session = async_sessionmaker(_engine, expire_on_commit=False)
+engine: AsyncEngine = _engine_instance
+async_session_factory: async_sessionmaker[AsyncSession] = _session_factory
 
-
-async def get_session() -> AsyncGenerator[AsyncSession, None]:
-    """Provide a database session and ensure proper cleanup."""
-    try:
-        async with _Session() as session:
-            yield session
-    except Exception as exc:  # pragma: no cover - infrastructure failure
-        raise AgentFlowError("Database session error") from exc
+__all__ = ["engine", "async_session_factory", "get_session"]

--- a/tests/db/test_session.py
+++ b/tests/db/test_session.py
@@ -1,0 +1,33 @@
+"""Tests for the legacy session module."""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine as sa_create_async_engine
+
+
+@pytest.mark.asyncio
+async def test_session_reexports_database_get_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_session should be re-exported from the database module."""
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("SECRET_KEY", "test")
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setenv("QDRANT_URL", "http://localhost:6333")
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine",
+        lambda url, **_: sa_create_async_engine(url),
+    )
+
+    database_mod = importlib.reload(importlib.import_module("apps.api.app.database"))
+    session_mod = importlib.reload(importlib.import_module("apps.api.app.db.session"))
+
+    assert session_mod.get_session is database_mod.get_session
+
+    async for session in session_mod.get_session():
+        assert isinstance(session, AsyncSession)


### PR DESCRIPTION
## Summary
- reuse database engine and sessionmaker in legacy session module
- expose get_session from central database utilities
- add regression test covering session re-export

## Testing
- `ruff check apps/ tests/` (fails: existing lint errors)
- `mypy apps/` (fails: 23 errors)
- `bandit -r apps/`
- `pytest tests/ -v` (fails: ENCRYPTION_KEY not configured, duplicate test module names)
- `pytest tests/db/test_session.py -v`

------
https://chatgpt.com/codex/tasks/task_e_68a9afaeaf348322b3093e11934e9081