### PR TITLE
build: add uv-based Python 3.10 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10-slim
+
+ENV UV_INSTALL_DIR=/usr/local/bin
+
+# Install curl for installing uv
+RUN apt-get update && apt-get install -y curl build-essential && rm -rf /var/lib/apt/lists/*
+
+# Install uv using official script
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+ENV PATH="/root/.local/bin:/root/.cargo/bin:${PATH}"
+
+WORKDIR /app
+
+# Copy dependency files first for caching
+COPY pyproject.toml uv.lock ./
+
+# Install dependencies into .venv
+RUN uv sync --frozen
+
+# Copy the rest of the application code
+COPY . .
+
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,14 @@
 version: "3.8"
 services:
   api:
-    build: .
-    command: uvicorn apps.api.app.main:app --host 0.0.0.0 --port 8000
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app
+    command: uv run uvicorn apps.api.app.main:app --host 0.0.0.0 --port 8000
     environment:
-      DATABASE_URL: postgresql+psycopg://postgres:postgres@postgres:5432/agentflow
-      REDIS_URL: redis://redis:6379/0
+      DATABASE_URL: ${DATABASE_URL}
+      REDIS_URL: ${REDIS_URL}
     depends_on:
       postgres:
         condition: service_healthy
@@ -14,10 +17,13 @@ services:
     ports: ["8000:8000"]
 
   mcp:
-    build: .
-    command: python apps/mcp/server.py
+    build:
+      context: .
+      dockerfile: Dockerfile
+    working_dir: /app
+    command: uv run python apps/mcp/server.py
     environment:
-      MCP_TRANSPORT: stdio
+      MCP_TRANSPORT: ${MCP_TRANSPORT:-stdio}
     depends_on:
       - api
 


### PR DESCRIPTION
## Summary
- add root Dockerfile targeting python:3.10-slim with uv and cached dependency install
- run API and MCP via `uv run` and supply secrets through environment variables

## Testing
- `uv run black apps/ tests/`
- `uv run isort apps/ tests/`
- `uv run ruff check apps/ tests/` *(fails: multiple lint errors)*
- `uv run mypy apps/`
- `uvx bandit -r apps/`
- `uv run --with pytest-asyncio --with pytest-cov pytest tests/ -v` *(fails: missing dependencies and configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a9b50d497083229013b9484e366a4e