### PR TITLE
docs: standardize uv usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,28 @@ agentflow/
    - Frontend UI: http://localhost:3000
    - Health Check: http://localhost:8000/health
 
+### Dependency Management & Testing
+
+Use [uv](https://astral.sh/uv) for Python dependency management.
+
+#### Add or Remove Dependencies
+```bash
+uv add <package>
+uv remove <package>
+```
+
+#### Export Requirements
+```bash
+uv export --format=requirements-txt --output requirements.txt
+```
+
+#### Run Tests
+```bash
+uv run pytest
+```
+
+> **Security note:** Store secrets such as API keys in environment variables. Never commit them to source control.
+
 ## 🔧 Core Concepts & Architecture
 
 ### Memory Management System

--- a/apps/api/app/middleware/AGENTS.md
+++ b/apps/api/app/middleware/AGENTS.md
@@ -24,7 +24,7 @@ This document provides essential context for AI models interacting with this mid
     - `uvicorn[standard]` - ASGI server
     - `redis>=4.3.0` - Rate limiting backend
 *   **Platforms:** Linux containers, Kubernetes deployments, cloud platforms (AWS/GCP/Azure)
-*   **Package Manager:** pip with requirements.txt, optionally uv for faster dependency resolution
+*   **Package Manager:** uv with `pyproject.toml` and `uv.lock`
 
 ## 3. Architectural Patterns & Structure
 *   **Overall Architecture:** ASGI middleware stack with layered observability - security middleware first, then authentication, rate limiting, tracing, and finally application logic
@@ -72,12 +72,11 @@ This document provides essential context for AI models interacting with this mid
 *   **CI/CD Pipeline:** `.github/workflows/test.yml` - Automated testing, linting, and security checks
 
 ## 6. Development & Testing Workflow
-*   **Local Development Environment:** 
-    1. Create virtual environment: `python -m venv .venv && source .venv/bin/activate`
-    2. Install dependencies: `pip install -r requirements-dev.txt`
-    3. Set up pre-commit hooks: `pre-commit install`
-    4. Start Redis for rate limiting: `docker run -d -p 6379:6379 redis:7-alpine`
-    5. Run application: `uvicorn src.main:app --reload --log-level debug`
+*   **Local Development Environment:**
+    1. Install dependencies: `uv sync`
+    2. Set up pre-commit hooks: `pre-commit install`
+    3. Start Redis for rate limiting: `docker run -d -p 6379:6379 redis:7-alpine`
+    4. Run application: `uv run uvicorn src.main:app --reload --log-level debug`
 *   **Task Configuration:** Use Makefile or just commands for common tasks:
     - `make test` - Run full test suite with coverage
     - `make lint` - Run ruff linting and Black formatting

--- a/infra/AGENTS.md
+++ b/infra/AGENTS.md
@@ -90,14 +90,15 @@ secrets:
 # Multi-stage Dockerfile example
 FROM python:3.11-slim as builder
 WORKDIR /app
-COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-dev
 
 FROM python:3.11-slim as runtime
 RUN groupadd -r appuser && useradd -r -g appuser appuser
 WORKDIR /app
-COPY --from=builder /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
+COPY --from=builder /app/.venv /app/.venv
 COPY . .
+ENV PATH="/app/.venv/bin:$PATH"
 USER appuser
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- document uv-based dependency workflow and testing
- update middleware and infrastructure guides to use `uv sync`

## Testing
- `uv run pytest tests/ -v --cov=apps --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_68a9b6a482fc8322b89488e285f150e9