### PR TITLE
ci: enforce coverage threshold in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,4 +41,4 @@ jobs:
       - run: uv run black --check apps/ tests/
       - run: uv run ruff check apps/ tests/
       - run: uv run mypy apps/
-      - run: uv run pytest
+      - run: uv run pytest --cov=apps --cov-report=term-missing --cov-fail-under=80


### PR DESCRIPTION
## Summary
- run pytest with coverage in CI
- enforce 80% coverage threshold in lint workflow

## Testing
- `uv run black --check apps/ tests/`
- `uv run ruff check apps/ tests/` *(fails: numerous style violations)*
- `uv run mypy apps/` *(fails: missing stubs and type errors)*
- `uv run pytest --cov=apps --cov-report=term-missing --cov-fail-under=80` *(fails: missing dependencies and config)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cbc89c948322bfb106be4a1432aa