### PR TITLE
feat(auth): async password helpers and tests

### DIFF
--- a/apps/api/app/utils/password.py
+++ b/apps/api/app/utils/password.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from passlib.context import CryptContext  # type: ignore[import-untyped]
 
 from ..exceptions import PasswordHashError
@@ -43,4 +45,26 @@ def verify_password(password: str, hashed: str) -> bool:
     try:
         return _pwd_context.verify(password, hashed)
     except Exception as exc:  # pragma: no cover - library failure
+        raise PasswordHashError("Verification failed") from exc
+
+
+async def hash_password_async(password: str) -> str:
+    """Asynchronously hash a password using a thread pool."""
+
+    try:
+        return await asyncio.to_thread(hash_password, password)
+    except PasswordHashError:
+        raise
+    except Exception as exc:  # pragma: no cover - unexpected error
+        raise PasswordHashError("Hashing failed") from exc
+
+
+async def verify_password_async(password: str, hashed: str) -> bool:
+    """Asynchronously verify a password against a hash."""
+
+    try:
+        return await asyncio.to_thread(verify_password, password, hashed)
+    except PasswordHashError:
+        raise
+    except Exception as exc:  # pragma: no cover - unexpected error
         raise PasswordHashError("Verification failed") from exc

--- a/tests/api/test_auth_service_async.py
+++ b/tests/api/test_auth_service_async.py
@@ -1,0 +1,61 @@
+"""AuthService password hashing/verification tests."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pyotp
+import pytest
+
+from apps.api.app.exceptions import PasswordHashError
+from apps.api.app.services.auth import AuthService
+
+
+@pytest.mark.asyncio
+async def test_register_user_uses_async_hash(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = SimpleNamespace(add=Mock(), commit=AsyncMock(), rollback=AsyncMock())
+    service = AuthService(db)
+    hasher = AsyncMock(return_value="hashed")
+    monkeypatch.setattr("apps.api.app.services.auth.hash_password_async", hasher)
+    secret = await service.register_user("a@b.com", "Password1!")
+    hasher.assert_awaited_once_with("Password1!")
+    assert secret
+
+
+@pytest.mark.asyncio
+async def test_register_user_hash_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    db = SimpleNamespace(add=Mock(), commit=AsyncMock(), rollback=AsyncMock())
+    service = AuthService(db)
+    hasher = AsyncMock(side_effect=PasswordHashError("boom"))
+    monkeypatch.setattr("apps.api.app.services.auth.hash_password_async", hasher)
+    with pytest.raises(PasswordHashError):
+        await service.register_user("a@b.com", "Password1!")
+    hasher.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_uses_async_verify(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AuthService(AsyncMock())
+    user = SimpleNamespace(hashed_password="hashed", otp_secret="secret")
+    service._get_user = AsyncMock(return_value=user)
+    verifier = AsyncMock(return_value=True)
+    monkeypatch.setattr("apps.api.app.services.auth.verify_password_async", verifier)
+    monkeypatch.setattr(pyotp, "TOTP", lambda _: SimpleNamespace(verify=Mock(return_value=True)))
+    result = await service.authenticate_user("a@b.com", "Password1!", "0000")
+    verifier.assert_awaited_once_with("Password1!", "hashed")
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_authenticate_user_verify_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    service = AuthService(AsyncMock())
+    user = SimpleNamespace(hashed_password="hashed", otp_secret="secret")
+    service._get_user = AsyncMock(return_value=user)
+    verifier = AsyncMock(side_effect=PasswordHashError("boom"))
+    monkeypatch.setattr("apps.api.app.services.auth.verify_password_async", verifier)
+    monkeypatch.setattr(pyotp, "TOTP", lambda _: SimpleNamespace(verify=Mock(return_value=True)))
+    with pytest.raises(PasswordHashError):
+        await service.authenticate_user("a@b.com", "Password1!", "0000")
+    verifier.assert_awaited_once()
+


### PR DESCRIPTION
## Summary
- add asyncio-based password hash/verify wrappers
- integrate async password helpers into AuthService
- test AuthService registration/auth flows with async wrappers

## Testing
- `pre-commit run --files apps/api/app/utils/password.py apps/api/app/services/auth.py tests/api/test_auth_service_async.py` *(fails: biome: not found)*
- `pytest tests/api/test_auth_service_async.py -v`
- `pytest tests/api/test_auth_api.py::test_register_and_login -v` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_68a9f362fe988322a587bca909e67ffb