### PR TITLE
chore: add service users and healthchecks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
-version: "3.8"
 services:
   api:
+    user: "1000:1000"
     build:
       context: .
       dockerfile: Dockerfile
@@ -15,8 +15,15 @@ services:
       redis:
         condition: service_started
     ports: ["8000:8000"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   mcp:
+    user: "1000:1000"
     build:
       context: .
       dockerfile: Dockerfile
@@ -26,8 +33,15 @@ services:
       MCP_TRANSPORT: ${MCP_TRANSPORT:-stdio}
     depends_on:
       - api
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   postgres:
+    user: "1000:1000"
     image: postgres:16
     environment:
       POSTGRES_USER: postgres
@@ -35,28 +49,50 @@ services:
       POSTGRES_DB: agentflow
     ports: ["5432:5432"]
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD", "pg_isready", "-U", "postgres"]
       interval: 5s
       timeout: 5s
-      retries: 20
+      retries: 5
 
   redis:
+    user: "1000:1000"
     image: redis:7
     ports: ["6379:6379"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   qdrant:
+    user: "1000:1000"
     image: qdrant/qdrant:latest
     ports: ["6333:6333"]
     volumes:
       - qdrant_storage:/qdrant/storage
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6333/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   neo4j:
+    user: "1000:1000"
     image: neo4j:5
     environment:
       NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-password}
     ports: ["7474:7474", "7687:7687"]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7474"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
   r2r:
+    user: "1000:1000"
     image: sciphi/r2r:latest
     environment:
       - R2R_CONFIG_NAME=full
@@ -67,6 +103,12 @@ services:
     depends_on:
       - postgres
       - redis
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7272/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 5s
 
 volumes:
   qdrant_storage: {}


### PR DESCRIPTION
## Summary
- drop docker-compose version declaration
- run all services as non-root with basic healthchecks

## Testing
- `pytest tests/ -v --cov=apps --cov-report=term-missing --cov-fail-under=90` *(fails: ENCRYPTION_KEY not configured)*
- `docker compose up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ff4a94f88322a010f209bc8ce7ed