### PR TITLE
feat: add responsive layout components

### DIFF
--- a/frontend/app/root-layout.test.ts
+++ b/frontend/app/root-layout.test.ts
@@ -33,7 +33,10 @@ async function testLayout() {
   const html = renderToStaticMarkup(
     React.createElement(RootLayout, null, React.createElement(Child, null)),
   );
-  assert.ok(html.includes('<nav'));
+  assert.ok(html.includes('<header'));
+  assert.ok(html.includes('<aside'));
+  assert.ok(html.includes('md:grid'));
+  assert.ok(html.includes('md:grid-cols-[sidebar_16rem_main_1fr]'));
   await new Promise((r) => setTimeout(r, 0));
   assert.equal(storage.accessToken, 'access1');
 }

--- a/frontend/app/root-layout.ts
+++ b/frontend/app/root-layout.ts
@@ -1,7 +1,9 @@
 import React, { type ReactNode } from 'react';
 import { AuthProvider } from '../providers/auth-provider.ts';
 import { ThemeProvider } from '../providers/theme-provider.ts';
-import Navigation from '../components/layout/navigation.ts';
+import Header from '../components/layout/header.tsx';
+import Sidebar from '../components/layout/sidebar.tsx';
+import Main from '../components/layout/main.tsx';
 import { ErrorBoundary } from '../components/layout/error-boundary.ts';
 
 export default function RootLayout({ children }: { children: ReactNode }): JSX.Element {
@@ -10,7 +12,7 @@ export default function RootLayout({ children }: { children: ReactNode }): JSX.E
     { lang: 'en' },
     React.createElement(
       'body',
-      null,
+      { className: 'md:grid md:grid-cols-[sidebar_16rem_main_1fr]' },
       React.createElement(
         ErrorBoundary,
         null,
@@ -20,8 +22,9 @@ export default function RootLayout({ children }: { children: ReactNode }): JSX.E
           React.createElement(
             AuthProvider,
             null,
-            React.createElement(Navigation, null),
-            children,
+            React.createElement(Header, null),
+            React.createElement(Sidebar, null),
+            React.createElement(Main, null, children),
           ),
         ),
       ),

--- a/frontend/components/layout/header.test.ts
+++ b/frontend/components/layout/header.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Header from './header.tsx';
+
+const html = renderToStaticMarkup(React.createElement(Header));
+assert.ok(html.includes('<header'));
+assert.ok(html.includes('md:hidden'));
+
+console.log('Header tests passed');

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -1,0 +1,17 @@
+import React, { type ReactNode } from 'react';
+import Navigation from './navigation.ts';
+
+interface HeaderProps {
+  children?: ReactNode;
+}
+
+export default function Header({ children }: HeaderProps): JSX.Element {
+  return React.createElement(
+    'header',
+    { className: 'md:hidden border-b' },
+    React.createElement(Navigation, null),
+    children,
+  );
+}
+
+export type { HeaderProps };

--- a/frontend/components/layout/main.test.ts
+++ b/frontend/components/layout/main.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Main from './main.tsx';
+
+const html = renderToStaticMarkup(
+  React.createElement(Main, null, React.createElement('div', null, 'content')),
+);
+assert.ok(html.includes('<main'));
+assert.ok(html.includes('content'));
+
+console.log('Main tests passed');

--- a/frontend/components/layout/main.tsx
+++ b/frontend/components/layout/main.tsx
@@ -1,0 +1,11 @@
+import React, { type ReactNode } from 'react';
+
+interface MainProps {
+  children: ReactNode;
+}
+
+export default function Main({ children }: MainProps): JSX.Element {
+  return React.createElement('main', { className: 'p-4' }, children);
+}
+
+export type { MainProps };

--- a/frontend/components/layout/sidebar.test.ts
+++ b/frontend/components/layout/sidebar.test.ts
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Sidebar from './sidebar.tsx';
+
+const html = renderToStaticMarkup(React.createElement(Sidebar));
+assert.ok(html.includes('<aside'));
+assert.ok(html.includes('hidden md:block'));
+
+console.log('Sidebar tests passed');

--- a/frontend/components/layout/sidebar.tsx
+++ b/frontend/components/layout/sidebar.tsx
@@ -1,0 +1,35 @@
+import React, { type ReactNode } from 'react';
+import Link from 'next/link.js';
+
+interface SidebarItem {
+  href: string;
+  label: string;
+}
+
+interface SidebarProps {
+  items?: SidebarItem[];
+  children?: ReactNode;
+}
+
+const DEFAULT_ITEMS: SidebarItem[] = [
+  { href: '/', label: 'Home' },
+  { href: '/dashboard', label: 'Dashboard' },
+];
+
+export default function Sidebar({ items = DEFAULT_ITEMS, children }: SidebarProps): JSX.Element {
+  const list = items.map((item) =>
+    React.createElement(
+      'li',
+      { key: item.href, className: 'p-2' },
+      React.createElement(Link, { href: item.href }, item.label),
+    ),
+  );
+  return React.createElement(
+    'aside',
+    { className: 'hidden md:block w-64 border-r p-4' },
+    React.createElement('ul', { className: 'space-y-2' }, ...list),
+    children,
+  );
+}
+
+export type { SidebarProps, SidebarItem };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --formatter-enabled=false --assist-enabled=false .",
     "format": "biome format .",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx components/layout/header.test.ts && tsx components/layout/sidebar.test.ts && tsx components/layout/main.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add Header, Sidebar, and Main layout components
- compose new layout components in root layout with responsive grid
- cover layout responsiveness with new tests

## Testing
- `npm run lint` (fails: unused imports, explicit any, etc.)
- `npm run type-check` (fails: type errors in existing files)
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1d7ccb44832280394ce4f16a7589