### PR TITLE
feat(frontend): add dashboard knowledge pages

### DIFF
--- a/frontend/app/(dashboard)/knowledge/page.test.tsx
+++ b/frontend/app/(dashboard)/knowledge/page.test.tsx
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { renderToStaticMarkup } from 'react-dom/server';
+import KnowledgePage from './page.tsx';
+
+process.env.NEXT_PUBLIC_API_BASE_URL = 'http://localhost';
+globalThis.fetch = async () =>
+  new Response(JSON.stringify([{ id: '1', title: 'Doc1' }]), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+(async () => {
+  const html = renderToStaticMarkup(await KnowledgePage());
+  assert.ok(html.includes('Knowledge'));
+  assert.ok(html.includes('Doc1'));
+  console.log('KnowledgePage tests passed');
+})();

--- a/frontend/app/(dashboard)/knowledge/page.tsx
+++ b/frontend/app/(dashboard)/knowledge/page.tsx
@@ -1,0 +1,61 @@
+// biome-ignore lint/correctness/noUnusedImports: React import required for JSX
+import React from 'react';
+import type { KnowledgeItemProps } from '../../../components/knowledge/knowledge-item.tsx';
+import KnowledgeList from '../../../components/knowledge/knowledge-list.tsx';
+
+class KnowledgeFetchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'KnowledgeFetchError';
+  }
+}
+
+async function fetchKnowledge(): Promise<KnowledgeItemProps[]> {
+  const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+  if (typeof baseUrl !== 'string' || !baseUrl) {
+    throw new KnowledgeFetchError('API base URL missing');
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  const url = `${baseUrl}/knowledge`;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(url, { signal: controller.signal });
+      if (!res.ok) {
+        throw new KnowledgeFetchError(`Request failed: ${res.status}`);
+      }
+      const data = (await res.json()) as unknown;
+      if (!Array.isArray(data)) {
+        throw new KnowledgeFetchError('Invalid response');
+      }
+      clearTimeout(timeout);
+      return data.map((d) => ({
+        id: String((d as { id: unknown }).id),
+        title: String((d as { title: unknown }).title),
+      }));
+    } catch (error) {
+      if (attempt === 2) {
+        const message =
+          error instanceof Error ? error.message : 'Unknown error';
+        throw new KnowledgeFetchError(message);
+      }
+    }
+  }
+  throw new KnowledgeFetchError('Failed to fetch knowledge');
+}
+
+export default async function KnowledgePage(): Promise<JSX.Element> {
+  let items: KnowledgeItemProps[] = [];
+  try {
+    items = await fetchKnowledge();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    console.error(new KnowledgeFetchError(message));
+  }
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-semibold">Knowledge</h1>
+      <KnowledgeList items={items} />
+    </div>
+  );
+}

--- a/frontend/app/(dashboard)/page.test.tsx
+++ b/frontend/app/(dashboard)/page.test.tsx
@@ -1,0 +1,9 @@
+import assert from 'node:assert/strict';
+import { renderToStaticMarkup } from 'react-dom/server';
+import DashboardPage from './page.tsx';
+
+const html = renderToStaticMarkup(DashboardPage());
+assert.ok(html.includes('Dashboard Overview'));
+assert.ok(html.includes('/agents'));
+assert.ok(html.includes('/knowledge'));
+console.log('DashboardPage tests passed');

--- a/frontend/app/(dashboard)/page.tsx
+++ b/frontend/app/(dashboard)/page.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link.js';
+// biome-ignore lint/correctness/noUnusedImports: React import required for JSX
+import React from 'react';
+
+export default function DashboardPage(): JSX.Element {
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-xl font-semibold">Dashboard Overview</h1>
+      <ul className="space-y-2">
+        <li>
+          <Link href="/agents" className="text-blue-600">
+            Agents
+          </Link>
+        </li>
+        <li>
+          <Link href="/knowledge" className="text-blue-600">
+            Knowledge
+          </Link>
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/components/knowledge/knowledge-item.tsx
+++ b/frontend/components/knowledge/knowledge-item.tsx
@@ -1,0 +1,20 @@
+// biome-ignore lint/correctness/noUnusedImports: React import required for JSX
+import React from 'react';
+
+interface KnowledgeItemProps {
+  id: string;
+  title: string;
+}
+
+export default function KnowledgeItem({
+  id,
+  title,
+}: KnowledgeItemProps): JSX.Element {
+  return (
+    <li id={id} className="p-2 border">
+      {title}
+    </li>
+  );
+}
+
+export type { KnowledgeItemProps };

--- a/frontend/components/knowledge/knowledge-list.tsx
+++ b/frontend/components/knowledge/knowledge-list.tsx
@@ -1,0 +1,21 @@
+// biome-ignore lint/correctness/noUnusedImports: React import required for JSX
+import React from 'react';
+import KnowledgeItem, { type KnowledgeItemProps } from './knowledge-item.tsx';
+
+interface KnowledgeListProps {
+  items: KnowledgeItemProps[];
+}
+
+export default function KnowledgeList({
+  items,
+}: KnowledgeListProps): JSX.Element {
+  return (
+    <ul className="space-y-2">
+      {items.map((item) => (
+        <KnowledgeItem key={item.id} {...item} />
+      ))}
+    </ul>
+  );
+}
+
+export type { KnowledgeListProps };

--- a/frontend/components/layout/navigation.test.ts
+++ b/frontend/components/layout/navigation.test.ts
@@ -6,6 +6,8 @@ import Navigation from './navigation.ts';
 const html = renderToStaticMarkup(React.createElement(Navigation));
 assert.ok(html.includes('Home'));
 assert.ok(html.includes('Dashboard'));
+assert.ok(html.includes('Agents'));
+assert.ok(html.includes('Knowledge'));
 assert.ok(html.includes('md:flex'));
 assert.ok(html.includes('md:hidden'));
 

--- a/frontend/components/layout/navigation.ts
+++ b/frontend/components/layout/navigation.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import React, { useState } from 'react';
 import Link from 'next/link.js';
+import React, { useState } from 'react';
 
 interface NavItem {
   href: string;
@@ -11,6 +11,8 @@ interface NavItem {
 const NAV_ITEMS: NavItem[] = [
   { href: '/', label: 'Home' },
   { href: '/dashboard', label: 'Dashboard' },
+  { href: '/agents', label: 'Agents' },
+  { href: '/knowledge', label: 'Knowledge' },
 ];
 
 export default function Navigation(): JSX.Element {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "lint": "biome check --formatter-enabled=false --assist-enabled=false .",
     "format": "biome format .",
     "type-check": "tsc --noEmit",
-    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx components/layout/header.test.ts && tsx components/layout/sidebar.test.ts && tsx components/layout/main.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",
+    "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx components/layout/header.test.ts && tsx components/layout/sidebar.test.ts && tsx components/layout/main.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/page.test.tsx\" && tsx \"app/(dashboard)/knowledge/page.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",
     "test:coverage": "jest --coverage"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add dashboard overview with links to agents and knowledge
- create knowledge page with robust fetch and list components
- extend navigation and tests for new knowledge section

## Testing
- `npx biome check "app/(dashboard)/page.tsx" "app/(dashboard)/knowledge/page.tsx" "app/(dashboard)/page.test.tsx" "app/(dashboard)/knowledge/page.test.tsx" components/knowledge/knowledge-item.tsx components/knowledge/knowledge-list.tsx components/layout/navigation.ts components/layout/navigation.test.ts package.json`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa1ed356c08322bd3f861327b528f4