### PR TITLE
chore(frontend): add lint and type-check scripts

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run lint
+      - run: npm run type-check
 
   python:
     runs-on: ubuntu-latest

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -258,3 +258,7 @@ test('should handle agent update', async () => {
 *   **NEVER** ignore accessibility requirements
 *   **NEVER** hardcode API URLs or sensitive configuration
 *   **NEVER** use Pages Router (App Router only)
+
+## 13. Programmatic Checks
+*   **MANDATORY:** Run `npm run lint` before committing changes
+*   **MANDATORY:** Run `npm run type-check` to verify TypeScript types

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "biome check --formatter-enabled=false --assist-enabled=false .",
+    "lint": "biome check .",
     "format": "biome format .",
     "type-check": "tsc --noEmit",
     "test": "tsx lib/api.test.ts && tsx providers/auth-provider.test.ts && tsx providers/theme-provider.test.ts && tsx components/layout/error-boundary.test.ts && tsx components/layout/navigation.test.ts && tsx components/layout/header.test.ts && tsx components/layout/sidebar.test.ts && tsx components/layout/main.test.ts && tsx app/root-layout.test.ts && tsx \"app/(auth)/layout.test.tsx\" && tsx \"app/(dashboard)/page.test.tsx\" && tsx \"app/(dashboard)/knowledge/page.test.tsx\" && tsx \"app/(dashboard)/agents/page.test.tsx\" && tsx \"app/(dashboard)/agents/layout.test.tsx\" && tsx \"app/(dashboard)/agents/[id]/edit/page.test.tsx\" && tsx \"app/(dashboard)/memory/page.test.tsx\" && jest",


### PR DESCRIPTION
## Summary
- add lint and type-check scripts to frontend package
- document frontend lint and type-check procedures
- run lint and type-check in CI frontend job

## Testing
- `npm run lint` (fails: unused imports and formatting issues)
- `npm run type-check` (fails: TypeScript errors)
- `pre-commit run --files frontend/package.json frontend/AGENTS.md .github/workflows/lint.yml` (fails: biome check errors)


------
https://chatgpt.com/codex/tasks/task_e_68aa2128de188322bff4ad7b372eca2a