### PR TITLE
Validate RAG API URL and tighten HTTP error handling

### DIFF
--- a/apps/mcp/tools/rag_search.py
+++ b/apps/mcp/tools/rag_search.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 from mcp.server.fastmcp import Context
+from pydantic import AnyUrl, TypeAdapter, ValidationError
 
 from .middleware import with_middleware
 from .registry import registry
@@ -19,34 +20,51 @@ class RagSearchError(Exception):
     """Raised when RAG search fails."""
 
 
+def _get_rag_api_url() -> str:
+    api_url_raw = os.getenv("RAG_API_URL")
+    if not api_url_raw:
+        raise RagSearchError("RAG_API_URL not set")
+    try:
+        return str(TypeAdapter(AnyUrl).validate_python(api_url_raw))
+    except ValidationError as exc:
+        raise RagSearchError(f"Invalid RAG_API_URL: {api_url_raw}") from exc
+
+
+def _build_headers() -> dict[str, str]:
+    headers: dict[str, str] = {}
+    if api_key := os.getenv("RAG_API_KEY"):
+        headers["Authorization"] = f"Bearer {api_key}"
+    return headers
+
+
 @registry.register("rag_search")
 @with_middleware("rag_search", timeout_s=8)
 async def rag_search_tool(
     ctx: Context[Any, Any, Any], request: RagSearchRequest
 ) -> RagSearchResponse:
     """Perform RAG search via external API."""
-    api_url = os.getenv("RAG_API_URL")
-    if not api_url:
-        raise RagSearchError("RAG_API_URL not set")
-    headers: dict[str, str] = {}
-    api_key = os.getenv("RAG_API_KEY")
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
+    api_url = _get_rag_api_url()
+    headers = _build_headers()
     payload = request.model_dump()
     for attempt in range(3):
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 resp = await client.post(api_url, json=payload, headers=headers)
-                resp.raise_for_status()
-                data: Any = resp.json()
-                result = RagSearchResponse.model_validate(data)
-                await ctx.info("rag search success")
-                return result
-        except Exception as exc:
+            resp.raise_for_status()
+            data: Any = resp.json()
+            result = RagSearchResponse.model_validate(data)
+            await ctx.info("rag search success")
+            return result
+        except (httpx.HTTPError, asyncio.TimeoutError) as exc:
             wait = 2**attempt
             logger.warning("rag search attempt %s failed: %s", attempt + 1, exc)
             if attempt == 2:
-                await ctx.error(f"RAG search failed: {exc}")
-                raise RagSearchError(str(exc)) from exc
+                msg = (
+                    f"HTTP error: {exc}"
+                    if isinstance(exc, httpx.HTTPError)
+                    else "RAG search timed out"
+                )
+                await ctx.error(msg)
+                raise RagSearchError(msg) from exc
             await asyncio.sleep(wait)
     raise RagSearchError("unknown error")  # pragma: no cover


### PR DESCRIPTION
## Summary
- validate `RAG_API_URL` with `pydantic.AnyUrl` and raise `RagSearchError` when invalid
- handle `httpx.HTTPError` and `asyncio.TimeoutError` separately, logging and rethrowing as `RagSearchError`
- add unit tests for invalid URLs and HTTP failures in rag search tool

## Testing
- `ruff check apps/mcp/tools/rag_search.py tests/mcp/test_tools_rag_search.py`
- `pytest tests/mcp/test_tools_rag_search.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa28bf96e48322b48842c02cc25578