### PR TITLE
chore: require Python 3.11

### DIFF
--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -15,7 +15,7 @@ This document provides essential context for AI models interacting with the Agen
 
 ## 2. Core Technologies & Stack
 
-*   **Languages:** Python 3.10+, TypeScript 5.x, JavaScript ES2023
+*   **Languages:** Python 3.11+, TypeScript 5.x, JavaScript ES2023
 *   **Frameworks & Runtimes:** 
     - Backend: FastAPI 0.115.12+, Pydantic AI, LangGraph (orchestration), Mem0 (memory), R2R (RAG), AG2 (multi-agent)
     - Frontend: Next.js 14+ with App Router, React 18+, Tailwind CSS, Biome (linting/formatting)
@@ -93,7 +93,7 @@ This document provides essential context for AI models interacting with the Agen
 ## 6. Development & Testing Workflow
 
 *   **Local Development Environment:**
-    1. Install Python 3.10+ and uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+    1. Install Python 3.11+ and uv: `curl -LsSf https://astral.sh/uv/install.sh | sh`
     2. Install Node.js 20+ and npm for frontend development
     3. Start services: `docker compose -f docker-compose.dev.yml up -d`
     4. Backend setup: `cd apps/api && uv install && uvicorn app.main:app --reload`

--- a/AgentFlow-Functional-Requirements-Document.md
+++ b/AgentFlow-Functional-Requirements-Document.md
@@ -393,7 +393,7 @@ AgentFlow delivers a typed, production-grade agent platform unifying **LangGraph
 ## 9) Dependencies & Constraints
 
 * **Frameworks:** LangGraph, Pydantic-AI, Mem0, R2R, MCP.
-* **Infra:** **PostgreSQL 17.x**, **Redis 7.x**, **Qdrant (TLS)**, R2R service, FastAPI 0.115+, Python 3.10+.
+* **Infra:** **PostgreSQL 17.x**, **Redis 7.x**, **Qdrant (TLS)**, R2R service, FastAPI 0.115+, Python 3.11+.
 * **Frontend:** Next.js (App Router), React 18, TypeScript 5.x, Biome.
 * **Constraints:** Compose hygiene rules; TLS everywhere; no secrets in code; typed surfaces only.
 

--- a/apps/api/app/observability/AGENTS.md
+++ b/apps/api/app/observability/AGENTS.md
@@ -15,7 +15,7 @@ This document provides essential context for AI models interacting with the obse
 
 ## 2. Core Technologies & Stack
 
-* **Languages:** Python 3.10+ (primary), with OpenTelemetry SDK integration
+* **Languages:** Python 3.11+ (primary), with OpenTelemetry SDK integration
 * **Frameworks & Runtimes:** 
   - FastAPI 0.115.12+ with async/await patterns
   - OpenTelemetry Python SDK (latest stable) for distributed tracing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 name = "agentflow"
 version = "0.1.0"
 description = "AgentFlow MVP scaffold"
-requires-python = ">=3.11"
+requires-python = ">=3.11.0"
 dependencies = [
     "alembic==1.16.4",
     "cryptography==45.0.6",

--- a/tests/api/AGENTS.md
+++ b/tests/api/AGENTS.md
@@ -13,7 +13,7 @@ This document provides essential context for AI models working on API-specific t
     - Request/response validation with Pydantic models and structured logging verification
 
 ## 2. Core Technologies & Stack
-*   **Languages:** Python 3.10+ with async/await patterns, SQL for database validation
+*   **Languages:** Python 3.11+ with async/await patterns, SQL for database validation
 *   **Testing Framework:** 
     - pytest 7.x+ with pytest-asyncio for async endpoint testing
     - FastAPI TestClient for synchronous HTTP testing with dependency override support

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.11"
+requires-python = ">=3.11.0"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",


### PR DESCRIPTION
## Summary
- raise Python requirement to 3.11
- document Python 3.11 in workflows and testing guides
- update lockfile for Python 3.11

## Testing
- `docker compose config` *(fails: command not found)*
- `safety check` *(fails: unable to reach server)*
- `python3 -m pytest tests/security/` *(fails: No module named 'sqlalchemy')*
- `python3 -c "import jwt; print('JWT working')"`


------
https://chatgpt.com/codex/tasks/task_e_68ac81164cb88322b0b011e513d1c901