### PR TITLE
chore: parameterize fastapi-guard install

### DIFF
--- a/tests/test_install_security_deps.py
+++ b/tests/test_install_security_deps.py
@@ -1,0 +1,48 @@
+import asyncio
+import subprocess
+from subprocess import CalledProcessError, CompletedProcess
+
+import pytest
+
+from scripts.install_security_deps import (
+    DependencyInstallationError,
+    install_fastapi_guard,
+)
+
+
+@pytest.mark.asyncio
+async def test_install_fastapi_guard_respects_env_version(monkeypatch) -> None:
+    """Should install the version specified in FASTAPI_GUARD_VERSION."""
+    calls: dict[str, list[str]] = {}
+
+    def fake_run(cmd, capture_output=True, text=True, check=True):  # type: ignore[override]
+        calls.setdefault("cmds", []).append(cmd)
+        return CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    monkeypatch.setenv("FASTAPI_GUARD_VERSION", "4.0.3")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    await install_fastapi_guard()
+
+    assert any("fastapi-guard==4.0.3" in c for c in calls["cmds"])  # version used
+
+
+@pytest.mark.asyncio
+async def test_install_fastapi_guard_logs_error_on_failure(monkeypatch, caplog) -> None:
+    """Should log an error and raise when installation fails."""
+    async def dummy_sleep(_: float) -> None:
+        pass
+
+    def failing_run(*args, **kwargs):  # type: ignore[override]
+        raise CalledProcessError(1, "pip", stderr="boom")
+
+    monkeypatch.setenv("FASTAPI_GUARD_VERSION", "4.0.3")
+    monkeypatch.setattr(subprocess, "run", failing_run)
+    monkeypatch.setattr(asyncio, "sleep", dummy_sleep)
+
+    with caplog.at_level("ERROR"), pytest.raises(DependencyInstallationError) as exc:
+        await install_fastapi_guard()
+
+    assert "fastapi-guard==4.0.3" in str(exc.value)
+    assert "Attempt" in caplog.text
+


### PR DESCRIPTION
## Summary
- parameterize fastapi-guard version via `FASTAPI_GUARD_VERSION`
- add async install with retry and error logging
- introduce tests for install script

## Testing
- `docker-compose config` *(fails: command not found)*
- `PYENV_VERSION=3.11.12 python -m pytest tests/security/` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `safety check` *(fails: command not found)*
- `PYENV_VERSION=3.11.12 pytest tests/test_install_security_deps.py`
- `PYENV_VERSION=3.11.12 python -c "import jwt; print('JWT working')"`


------
https://chatgpt.com/codex/tasks/task_e_68ac867be1d0832282fee7588af99cbe